### PR TITLE
Publish v0.5.1 - Bureau Data Refinement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "0.4.4",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp_immigration_dashboard",
-      "version": "0.4.4",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@next/third-parties": "^15.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "dependencies": {

--- a/src/constants/bureauOptions.ts
+++ b/src/constants/bureauOptions.ts
@@ -7,6 +7,7 @@ interface BureauOption {
   coordinates?: [number, number];
   border?: string;
   background?: string;
+  children?: string[];
 }
 
 // Bureau Colors are based on the color palette of its Prefecture's flag
@@ -21,6 +22,7 @@ export const bureauOptions: BureauOption[] = [
     coordinates: [130.38832, 33.59066],
     border: 'rgba(0,104,178, 1)',
     background: 'rgba(0,104,178, 0.5)',
+    children: ['101740'],
   },
   {
     value: '101580',
@@ -37,6 +39,7 @@ export const bureauOptions: BureauOption[] = [
     coordinates: [136.86337, 35.11406],
     border: 'rgba(180, 65, 80, 1)',
     background: 'rgba(180, 65, 80, 0.5)',
+    children: ['101370'],
   },
   {
     value: '101740',
@@ -53,6 +56,7 @@ export const bureauOptions: BureauOption[] = [
     coordinates: [135.41185, 34.64141],
     border: 'rgba(51, 65, 154, 1)',
     background: 'rgba(51, 65, 154, 0.5)',
+    children: ['101480','101490'],
   },
   {
     value: '101010',
@@ -85,6 +89,7 @@ export const bureauOptions: BureauOption[] = [
     coordinates: [139.75653, 35.62823],
     border: 'rgba(75, 0, 130, 1)',
     background: 'rgba(75, 0, 130, 0.5)',
+    children: ['101190','101200','101210'],
   },
   {
     value: '101210',

--- a/src/utils/correctBureauAggregates.ts
+++ b/src/utils/correctBureauAggregates.ts
@@ -1,0 +1,120 @@
+// src/utils/correctBureauAggregates.ts
+// Non-mutating, O(1) access-time corrections for “管内” bureaus using bureau CODES.
+// Works directly on the e-Stat DATA_INF.VALUE entries and never mutates the source.
+
+export type EStatValue = {
+  [k: string]: string | undefined; // "@tab", "@cat01", "@cat02", "@cat03", "@time", "$", etc.
+  "@cat03": string;                // bureau code
+  "@time": string;                 // time code (e.g., 2025000707)
+  "$"?: string;                    // numeric value as string
+};
+
+type ClassEntry = { "@code": string; "@name": string };
+type ClassObj = {
+  "@id": string;
+  "@name": string;
+  CLASS: ClassEntry | ClassEntry[];
+};
+
+export type EStatData = {
+  GET_STATS_DATA: {
+    STATISTICAL_DATA: {
+      CLASS_INF: {
+        CLASS_OBJ: ClassObj | ClassObj[];
+      };
+      DATA_INF: {
+        VALUE: EStatValue | EStatValue[];
+      };
+    };
+  };
+};
+
+// Use code mapping (consistent with bureauOptions values)
+const AGGREGATE_CODE_MAPPING: Record<string, string[]> = {
+  // 東京管内(101170) minus 成田(101190), 羽田(101200), 横浜(101210)
+  "101170": ["101190", "101200", "101210"],
+  // 名古屋管内(101350) minus 中部空港(101370)
+  "101350": ["101370"],
+  // 大阪管内(101460) minus 関西空港(101480), 神戸(101490)
+  "101460": ["101480", "101490"],
+  // 福岡管内(101720) minus 那覇(101740)
+  "101720": ["101740"],
+};
+
+export function makeCorrectedAccessor(data: EStatData) {
+  const sd = data.GET_STATS_DATA.STATISTICAL_DATA;
+
+  // Normalize VALUE to array
+  const values = Array.isArray(sd.DATA_INF.VALUE)
+    ? sd.DATA_INF.VALUE
+    : [sd.DATA_INF.VALUE];
+
+  // Determine the coordinate keys present in this cube (robust to schema variance)
+  const sample = (values[0] ?? {}) as EStatValue;
+  const dimKeys = Object.keys(sample)
+    .filter((k) => k.startsWith("@"))
+    .filter((k) => k !== "@unit" && k !== "$");
+
+  const toKey = (coord: Partial<EStatValue>) =>
+    dimKeys.map((k) => String(coord[k as keyof EStatValue] ?? "")).join("|");
+
+  const toNum = (s?: string) =>
+    s == null || s === "" ? NaN : Number(s);
+
+  // Build an index of original values for fast lookup
+  const index = new Map<string, number>();
+  for (const v of values) {
+    index.set(toKey(v), toNum(v["$"]));
+  }
+
+  // Memoize corrected results
+  const memo = new Map<string, number>();
+
+  /**
+   * Returns the corrected numeric value for coord:
+   *  - For aggregate bureaus in AGGREGATE_CODE_MAPPING, subtracts branch totals
+   *    at the same coordinates (only @cat03 differs).
+   *  - For others, returns the original value.
+   * Returns NaN when base is missing/unparseable, mirroring parseInt behavior.
+   */
+  function getCorrectedValue(coord: Partial<EStatValue>): number {
+    const key = toKey(coord);
+    if (memo.has(key)) return memo.get(key)!;
+
+    const base = index.get(key);
+    if (typeof base !== "number") {
+      memo.set(key, NaN);
+      return NaN;
+    }
+
+    const bureau = String(coord["@cat03"] ?? "");
+    const branches = AGGREGATE_CODE_MAPPING[bureau];
+
+    if (!branches) {
+      memo.set(key, base);
+      return base;
+    }
+
+    let subtotal = 0;
+    for (const br of branches) {
+      const brKey = dimKeys
+        .map((dk) => (dk === "@cat03" ? br : String(coord[dk as keyof EStatValue] ?? "")))
+        .join("|");
+      const brVal = index.get(brKey);
+      if (typeof brVal === "number" && !Number.isNaN(brVal)) {
+        subtotal += brVal;
+      }
+    }
+
+    const corrected = base - subtotal;
+    memo.set(key, corrected);
+    return corrected;
+  }
+
+  return {
+    getCorrectedValue,
+    isAggregateBureauCode: (code: string) => code in AGGREGATE_CODE_MAPPING,
+    getBranchCodes: (code: string) => AGGREGATE_CODE_MAPPING[code] ?? [],
+    dimKeys,
+  };
+}

--- a/src/utils/dataTransform.ts
+++ b/src/utils/dataTransform.ts
@@ -35,7 +35,6 @@ export const transformData = (rawData: RawData): ImmigrationData[] => {
   const { getCorrectedValue } = makeCorrectedAccessor(rawData as unknown as EStatData);
 
   return values.map((entry) => {
-    // Keep your existing YYYY-MM formatting
     const month = entry['@time'].substring(0, 4) + '-' + entry['@time'].substring(8, 10);
 
     // IMPORTANT: include ALL '@' attrs present on the entry (e.g., '@tab', '@cat01', '@cat02', '@cat03', '@time', etc.)

--- a/src/utils/dataTransform.ts
+++ b/src/utils/dataTransform.ts
@@ -1,5 +1,6 @@
 // src/utils/dataTransform.ts
 import type { ImmigrationData } from '../hooks/useImmigrationData';
+import { type EStatData, type EStatValue, makeCorrectedAccessor } from './correctBureauAggregates';
 
 interface RawDataEntry {
   '@time': string;
@@ -13,10 +14,16 @@ interface RawData {
   GET_STATS_DATA: {
     STATISTICAL_DATA: {
       DATA_INF: {
-        VALUE: RawDataEntry[];
+        VALUE: RawDataEntry[] | RawDataEntry;
       };
     };
   };
+}
+
+function normalizeValues(rawData: RawData) {
+  const v = rawData?.GET_STATS_DATA?.STATISTICAL_DATA?.DATA_INF?.VALUE;
+  if (!v) return [] as RawDataEntry[];
+  return Array.isArray(v) ? v : [v];
 }
 
 export const transformData = (rawData: RawData): ImmigrationData[] => {
@@ -24,13 +31,32 @@ export const transformData = (rawData: RawData): ImmigrationData[] => {
     return [];
   }
 
-  const values = rawData.GET_STATS_DATA.STATISTICAL_DATA.DATA_INF.VALUE;
+  const values = normalizeValues(rawData);
+  const { getCorrectedValue } = makeCorrectedAccessor(rawData as unknown as EStatData);
 
-  return values.map((entry) => ({
-    month: entry['@time'].substring(0, 4) + '-' + entry['@time'].substring(8, 10),
-    bureau: entry['@cat03'],
-    type: entry['@cat02'],
-    value: parseInt(entry['$']),
-    status: entry['@cat01'],
-  }));
+  return values.map((entry) => {
+    // Keep your existing YYYY-MM formatting
+    const month = entry['@time'].substring(0, 4) + '-' + entry['@time'].substring(8, 10);
+
+    // IMPORTANT: include ALL '@' attrs present on the entry (e.g., '@tab', '@cat01', '@cat02', '@cat03', '@time', etc.)
+    const coord: Partial<EStatValue> = {};
+    Object.keys(entry).forEach((k) => {
+      if (k.startsWith('@') && k !== '@unit') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (coord as any)[k] = (entry as any)[k];
+      }
+    });
+
+    const corrected = getCorrectedValue(coord);
+    const original = parseInt(entry['$']);
+
+    return {
+      month,
+      bureau: entry['@cat03'],
+      type: entry['@cat02'],
+      // If for some reason a cell isn't found, fall back to original behavior
+      value: Number.isNaN(corrected) ? original : corrected,
+      status: entry['@cat01'],
+    };
+  });
 };


### PR DESCRIPTION
Version 0.5.1 brings a minor, yet impactful, update.

Special Thanks to [u/TheBipolarTurtle](https://www.reddit.com/user/TheBipolarTurtle/) on Reddit.
It was brought to my attention that certain data within the e-Stat dataset was aggregated.
I manually validated this against the data on e-Stat across a random selection of months and conditions.
This was not previously accounted for, resulting in unintentional duplication of data within some bureaus. Notably, this should only affect results for Tokyo, Osaka, Nagoya, and Fukuoka.

A new utility function has been created to deaggregate these values, where necessary.