### PR TITLE
fix: prevent spurious builds from data watcher cache expiration

### DIFF
--- a/.github/workflows/watcher.yaml
+++ b/.github/workflows/watcher.yaml
@@ -2,9 +2,9 @@ name: Data Watcher
 on:
   workflow_dispatch:
   schedule:
-    # Runs daily at 1:05 AM UTC (10:05 AM JST) from the 23rd-28th of each month
-    # e-Stat typically releases data on the 25th (weekdays only)
-    - cron: '5 1 23-28 * *'
+    # Runs daily at 1:05 AM UTC (10:05 AM JST)
+    # Keeps the cache alive and catches any mid-month data corrections from e-Stat
+    - cron: '5 1 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,6 +34,9 @@ jobs:
 
       - name: Set environment variable for CURRENT_MONTH
         run: echo "CURRENT_MONTH=$(date +'%Y-%m')" >> "$GITHUB_ENV"
+
+      - name: Set date cache key
+        run: echo "DATE_CACHE_KEY=estat-data-$(date +'%Y%m%d')" >> "$GITHUB_ENV"
 
       - name: Restore previous data
         uses: actions/cache@v4
@@ -73,9 +76,9 @@ jobs:
 
           # Check if previous data exists
           if [ ! -f "$prev_file" ]; then
-            echo "::notice::No previous data found, treating as new data"
-            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::notice::No previous data found - cache likely expired. Saving fresh copy without triggering build."
+            echo "changes_detected=false" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           # Extract current dates
@@ -104,12 +107,30 @@ jobs:
           echo "::notice::Workflow completed successfully - no data changes detected"
           exit 0
 
+      - name: Clean stale caches before refresh
+        if: steps.data-diff.outcome == 'failure' && steps.data-diff.outputs.changes_detected == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data } = await github.rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              key: 'estat-data-'
+            });
+            for (const cache of data.actions_caches) {
+              await github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id
+              });
+            }
+
       - name: Refresh cache to prevent expiration
         if: steps.data-diff.outcome == 'failure' && steps.data-diff.outputs.changes_detected == 'false'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.DATA_PATH }}
-          key: estat-data-${{ hashFiles(env.DATA_PATH) }}
+          key: ${{ env.DATE_CACHE_KEY }}
 
       - name: Cache new data
         if: steps.data-diff.outcome == 'success'


### PR DESCRIPTION
## Summary

- **Root cause**: The 23–28 schedule created a ~25-day inter-month gap that reliably exceeded the 7-day GitHub Actions cache TTL. On the first run of each month, the expired cache caused a missing `prev-` file, which was incorrectly treated as new data — triggering a spurious build (observed in run [22292165562](https://github.com/RetroHazard/JP_Immigration_Dashboard/actions/runs/22292165562)).
- **Schedule**: Changed from `23-28 * *` to `* * *` (daily) — eliminates the expiration gap entirely and also catches any mid-month data corrections from e-Stat.
- **Cache miss handling**: On a missing prev file, `changes_detected` is now set to `false` (exit 1) instead of `true` (exit 0) — routes through the no-changes path without triggering a build.
- **Cache refresh**: Switched from hash-based to date-based key (`estat-data-YYYYMMDD`) so refresh saves always create a new cache entry rather than silently no-oping when the same key already exists. Paired with a cleanup step to prevent stale entry accumulation.

## Test plan

- [x] Verify the workflow runs daily via the updated schedule
- [x] Manually trigger `workflow_dispatch` and confirm no build is fired when `SURVEY_DATE` is unchanged
- [ ] Confirm a build is triggered when `SURVEY_DATE` changes (next e-Stat release)
- [ ] Verify cache is saved with a `estat-data-YYYYMMDD` key after each no-changes run

🤖 Generated with [Claude Code](https://claude.com/claude-code)