### PR TITLE
Permalink to estimations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
   });
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [isEstimationExpanded, setIsEstimationExpanded] = useState(false);
+  const [isEstimationExpanded, setIsEstimationExpanded] = useState(true);
   const [activeChartIndex, setActiveChartIndex] = useState(0);
 
   // Get current chart's filter configuration

--- a/src/components/EstimationCard.tsx
+++ b/src/components/EstimationCard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type React from 'react';
 import { Icon } from '@iconify/react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 
 import { applicationOptions } from '../constants/applicationOptions';
 import type { ImmigrationData } from '../hooks/useImmigrationData';
@@ -38,6 +38,49 @@ const useUrlDetails: () => ApplicationDetails = () => {
       applicationDate: searchParams.get("applicationDate") || "",
     };
 }
+
+const ShareButton = ({appDetails} : {appDetails: ApplicationDetails}) => {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const [copied, setCopied] = useState(false);
+
+    const doShare = async () => {
+        // Mutable copy of the search params.
+        const mutableParams = new URLSearchParams(searchParams.toString());
+
+        mutableParams.set("bureau", appDetails.bureau);
+        mutableParams.set("type", appDetails.type);
+        mutableParams.set("applicationDate", appDetails.applicationDate);
+
+        const newRelativePath = `${pathname}?${mutableParams.toString()}`;
+        router.push(newRelativePath, { scroll: false });
+
+        try {
+            const fullUrl = `${window.location.origin}${newRelativePath}`;
+            await navigator.clipboard.writeText(fullUrl);
+
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy URL: ', err);
+        }
+    };
+
+    return (
+        <button
+          className="mt-3 flex items-center text-sm text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-500"
+          onClick={doShare}
+        >
+          <Icon
+            icon={copied ? 'material-symbols:check' : 'material-symbols:link'}
+            className="mr-1"
+          />
+          {copied ? 'Copied' : 'Permalink to these filters'}
+        </button>
+    );
+};
 
 export const EstimationCard: React.FC<EstimationCardProps> = ({
   data,
@@ -143,6 +186,8 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
               max={dateRange.max}
               onChange={(value) => setApplicationDetails({ ...applicationDetails, applicationDate: value })}
             />
+
+            <ShareButton appDetails={applicationDetails}/>
           </>
         )}
 

--- a/src/components/EstimationCard.tsx
+++ b/src/components/EstimationCard.tsx
@@ -1,8 +1,11 @@
 // src/components/EstimationCard.tsx
+'use client';
+
 import { useEffect, useMemo, useState } from 'react';
 
 import type React from 'react';
 import { Icon } from '@iconify/react';
+import { useSearchParams } from 'next/navigation';
 
 import { applicationOptions } from '../constants/applicationOptions';
 import type { ImmigrationData } from '../hooks/useImmigrationData';
@@ -26,6 +29,16 @@ interface ApplicationDetails {
   applicationDate: string;
 }
 
+const useUrlDetails: () => ApplicationDetails = () => {
+    const searchParams = useSearchParams();
+
+    return {
+      bureau: searchParams.get("bureau") || "",
+      type: searchParams.get("type") || "",
+      applicationDate: searchParams.get("applicationDate") || "",
+    };
+}
+
 export const EstimationCard: React.FC<EstimationCardProps> = ({
   data,
   variant = 'drawer',
@@ -33,11 +46,7 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
   onCollapse,
   onClose,
 }) => {
-  const [applicationDetails, setApplicationDetails] = useState<ApplicationDetails>({
-    bureau: '',
-    type: '',
-    applicationDate: '',
-  });
+  const [applicationDetails, setApplicationDetails] = useState<ApplicationDetails>(useUrlDetails());
   const [showDetails, setShowDetails] = useState(false);
   const [BlockMath, setBlockMath] = useState<React.ComponentType<{ math: string }> | null>(null);
 


### PR DESCRIPTION
Hi!

Sorry if this is too out-of-the-blue. I've been using this site to check my PR application state and love the simplicity, but was getting annoying having to keep remembering when I applied, so thought it'd be nice if the URL itself could save it for me -- so I could also share with friends and family.

Since you're using next, I learned (from asking Gemini, but not even directly copy-pasting its suggestions), that there's a router we can use to grab the URL search parameters synchronize it with the component state.

Hence (commit-by-commit):

1. URLs like `http://localhost:3000/?applicationDate=YYYY-MM-DD&bureau=101170&type=60` load the estimator with fields pre-filled (so the URL here is for a PR application from Shinagawa at the date).
2. After users see their estimate, they can grab a permalink to the form which both updates the page URL to reflect their search parameters and copies the URL to their clipboard for sharing.
3. I defaulted the estimator to be opened so that the URL's effects can be observed directly (and it doesn't seem to affect the moblie layout).

Please let me know if this is interesting and how we can proceed.

Thanks again for the awesome site!