### PR TITLE
Permalink to estimations (supersedes #43)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp_immigration_dashboard",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "^0.26.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "overrides": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 // App.tsx
 import { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 import type React from 'react';
 import { Icon } from '@iconify/react';
@@ -11,6 +12,7 @@ import { MobileLayout } from './components/layouts/MobileLayout';
 import { StatsSummary } from './components/StatsSummary';
 import { useTheme } from './contexts/ThemeContext';
 import { useImmigrationData } from './hooks/useImmigrationData';
+import { hasPermalinkParams } from './utils/urlApplicationDetails';
 import buildInfo from './buildInfo';
 
 interface Filters {
@@ -26,8 +28,11 @@ const App: React.FC = () => {
     type: 'all',
   });
 
+  const searchParams = useSearchParams();
+
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [isEstimationExpanded, setIsEstimationExpanded] = useState(false);
+  // Only auto-expand the estimator when a permalink has pre-filled it; otherwise stay collapsed by default.
+  const [isEstimationExpanded, setIsEstimationExpanded] = useState(() => hasPermalinkParams(searchParams));
   const [activeChartIndex, setActiveChartIndex] = useState(0);
 
   // Get current chart's filter configuration

--- a/src/components/EstimationCard.tsx
+++ b/src/components/EstimationCard.tsx
@@ -1,5 +1,6 @@
 // src/components/EstimationCard.tsx
 import { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import type React from 'react';
 import { Icon } from '@iconify/react';
@@ -9,6 +10,8 @@ import type { ImmigrationData } from '../hooks/useImmigrationData';
 import type { EstimatedDateResult } from '../utils/calculateEstimates';
 import { calculateEstimatedDate } from '../utils/calculateEstimates';
 import { nonAirportBureaus } from '../utils/getBureauData';
+import type { ApplicationDetails } from '../utils/urlApplicationDetails';
+import { getApplicationDetailsFromParams } from '../utils/urlApplicationDetails';
 import { FilterInput } from './common/FilterInput';
 import { FormulaTooltip, variableExplanations } from './common/FormulaTooltip';
 
@@ -20,11 +23,55 @@ interface EstimationCardProps {
   onClose?: () => void;
 }
 
-interface ApplicationDetails {
-  bureau: string;
-  type: string;
-  applicationDate: string;
+interface ShareButtonProps {
+  appDetails: ApplicationDetails;
 }
+
+const ShareButton: React.FC<ShareButtonProps> = ({ appDetails }) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [copied, setCopied] = useState(false);
+
+  const doShare = async () => {
+    // Mutable copy of the search params.
+    const mutableParams = new URLSearchParams(searchParams.toString());
+
+    // Only keep params with a selected value, so sharing a partially-filled form
+    // doesn't leave empty bureau/type/applicationDate params in the URL.
+    Object.entries(appDetails).forEach(([key, value]) => {
+      if (value) {
+        mutableParams.set(key, value);
+      } else {
+        mutableParams.delete(key);
+      }
+    });
+
+    const newRelativePath = `${pathname}?${mutableParams.toString()}`;
+    router.push(newRelativePath, { scroll: false });
+
+    try {
+      const fullUrl = `${window.location.origin}${newRelativePath}`;
+      await navigator.clipboard.writeText(fullUrl);
+
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy URL: ', err);
+    }
+  };
+
+  return (
+    <button
+      className="mt-3 flex items-center text-sm text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-500"
+      onClick={doShare}
+    >
+      <Icon icon={copied ? 'material-symbols:check' : 'material-symbols:link'} className="mr-1" />
+      {copied ? 'Copied' : 'Permalink to these filters'}
+    </button>
+  );
+};
 
 export const EstimationCard: React.FC<EstimationCardProps> = ({
   data,
@@ -33,11 +80,10 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
   onCollapse,
   onClose,
 }) => {
-  const [applicationDetails, setApplicationDetails] = useState<ApplicationDetails>({
-    bureau: '',
-    type: '',
-    applicationDate: '',
-  });
+  const searchParams = useSearchParams();
+  const [applicationDetails, setApplicationDetails] = useState<ApplicationDetails>(() =>
+    getApplicationDetailsFromParams(searchParams)
+  );
   const [showDetails, setShowDetails] = useState(false);
   const [BlockMath, setBlockMath] = useState<React.ComponentType<{ math: string }> | null>(null);
 
@@ -134,6 +180,8 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
               max={dateRange.max}
               onChange={(value) => setApplicationDetails({ ...applicationDetails, applicationDate: value })}
             />
+
+            <ShareButton appDetails={applicationDetails} />
           </>
         )}
 

--- a/src/components/EstimationCard.tsx
+++ b/src/components/EstimationCard.tsx
@@ -14,6 +14,7 @@ import type { ApplicationDetails } from '../utils/urlApplicationDetails';
 import { getApplicationDetailsFromParams } from '../utils/urlApplicationDetails';
 import { FilterInput } from './common/FilterInput';
 import { FormulaTooltip, variableExplanations } from './common/FormulaTooltip';
+import { IconTooltip } from './common/IconTooltip';
 
 interface EstimationCardProps {
   data: ImmigrationData[];
@@ -63,13 +64,19 @@ const ShareButton: React.FC<ShareButtonProps> = ({ appDetails }) => {
   };
 
   return (
-    <button
-      className="mt-3 flex items-center text-sm text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-500"
-      onClick={doShare}
-    >
-      <Icon icon={copied ? 'material-symbols:check' : 'material-symbols:link'} className="mr-1" />
-      {copied ? 'Copied' : 'Permalink to these filters'}
-    </button>
+    <IconTooltip label={copied ? 'Copied!' : 'Copy a permalink to these filters'}>
+      <button
+        onClick={doShare}
+        aria-label="Copy a permalink to these filters"
+        className={`flex size-7 items-center justify-center rounded-full transition-colors ${
+          copied
+            ? 'bg-indigo-100 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300'
+            : 'text-gray-500 hover:bg-gray-100 hover:text-indigo-600 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-indigo-300'
+        }`}
+      >
+        <Icon icon={copied ? 'material-symbols:check' : 'material-symbols:link'} className="text-base" />
+      </button>
+    </IconTooltip>
   );
 };
 
@@ -142,11 +149,17 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
 
   return (
     <div className="estimator-container">
-      <div className="flex-between border-b p-2 dark:border-gray-500">
-        <h2 className="section-title">Processing Time Estimator</h2>
-        <button onClick={variant === 'drawer' ? onClose : onCollapse} className="p-2 text-gray-500 hover:text-gray-700">
-          <Icon icon={variant === 'drawer' ? 'ci:close-md' : 'ci:chevron-right-duo'} className="flashing-chevron" />
-        </button>
+      <div className="flex-between gap-2 border-b p-2 dark:border-gray-500">
+        <h2 className="section-title min-w-0 truncate">Processing Time Estimator</h2>
+        <div className="flex shrink-0 items-center gap-1">
+          {!showDetails && <ShareButton appDetails={applicationDetails} />}
+          <button
+            onClick={variant === 'drawer' ? onClose : onCollapse}
+            className="p-2 text-gray-500 hover:text-gray-700"
+          >
+            <Icon icon={variant === 'drawer' ? 'ci:close-md' : 'ci:chevron-right-duo'} className="flashing-chevron" />
+          </button>
+        </div>
       </div>
       <div className="card-content-padded flex-1">
         {!showDetails && (
@@ -180,13 +193,17 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
               max={dateRange.max}
               onChange={(value) => setApplicationDetails({ ...applicationDetails, applicationDate: value })}
             />
-
-            <ShareButton appDetails={applicationDetails} />
           </>
         )}
 
         {estimatedDate && (
-          <div className="card-base-gray">
+          <div
+            className={`card-base-gray border-t-4 ${
+              estimatedDate.details.isPastDue
+                ? 'border-amber-400 dark:border-amber-500'
+                : 'border-indigo-400 dark:border-indigo-500'
+            }`}
+          >
             <div className="text-center text-lg font-medium text-gray-900 dark:text-gray-200">
               Estimated Completion Date
             </div>
@@ -251,33 +268,33 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
                 ) : (
                   <div className="rounded-xl bg-gray-100 p-2.5 text-xxs text-gray-600 shadow-lg dark:bg-gray-600 dark:text-gray-200">
                     <FormulaTooltip
-                    variables={{
-                      'D_{\\text{rem}}': variableExplanations['D_rem'],
-                      'Q_{\\text{pos}}': variableExplanations['Q_pos'],
-                      'R_{\\text{daily}}': variableExplanations['R_daily'],
-                    }}
-                  >
-                    <div className="mt-2 border-b border-gray-300 text-xxs">
-                      <BlockMath
-                        math={`
+                      variables={{
+                        'D_{\\text{rem}}': variableExplanations['D_rem'],
+                        'Q_{\\text{pos}}': variableExplanations['Q_pos'],
+                        'R_{\\text{daily}}': variableExplanations['R_daily'],
+                      }}
+                    >
+                      <div className="mt-2 border-b border-gray-300 text-xxs">
+                        <BlockMath
+                          math={`
                         \\begin{aligned}
                         &D_{\\text{rem}} \\approx \\left\\lbrack\\dfrac{Q_{\\text{pos}}}{R_{\\text{daily}}}\\right\\rbrack = \\left\\lbrack\\dfrac{{${estimatedDate.details.modelVariables.Q_pos.toFixed()}}}{${estimatedDate.details.modelVariables.R_daily.toFixed(2)}}\\right\\rbrack \\approx ${estimatedDate.details.modelVariables.D_rem.toFixed()} \\ \\text{d} \\\\
                         \\end{aligned}
                       `}
-                      />
-                    </div>
-                  </FormulaTooltip>
-                  <FormulaTooltip
-                    variables={{
-                      'C_{\\text{proc}}': variableExplanations['C_proc'],
-                      'E_{\\text{proc}}': variableExplanations['E_proc'],
-                      '\\sum P': variableExplanations['Sigma_P'],
-                      '\\sum D': variableExplanations['Sigma_D'],
-                    }}
-                  >
-                    <div className="mt-2 border-b border-gray-300 text-xxs">
-                      <BlockMath
-                        math={`
+                        />
+                      </div>
+                    </FormulaTooltip>
+                    <FormulaTooltip
+                      variables={{
+                        'C_{\\text{proc}}': variableExplanations['C_proc'],
+                        'E_{\\text{proc}}': variableExplanations['E_proc'],
+                        '\\sum P': variableExplanations['Sigma_P'],
+                        '\\sum D': variableExplanations['Sigma_D'],
+                      }}
+                    >
+                      <div className="mt-2 border-b border-gray-300 text-xxs">
+                        <BlockMath
+                          math={`
                         \\begin{aligned}
                         &\\text{where}\\
                         \\begin{cases}
@@ -287,28 +304,28 @@ export const EstimationCard: React.FC<EstimationCardProps> = ({
                         \\end{cases}
                         \\end{aligned}
                       `}
-                      />
-                    </div>
-                  </FormulaTooltip>
-                  <FormulaTooltip
-                    variables={{
-                      'Q_{\\text{app}}': variableExplanations['Q_app'],
-                      'C_{\\text{prev}}': variableExplanations['C_prev'],
-                      'N_{\\text{app}}': variableExplanations['N_app'],
-                      'P_{\\text{app}}': variableExplanations['P_app'],
-                    }}
-                  >
-                    <div className="mt-2 border-gray-300 text-xxs">
-                      <BlockMath
-                        math={`
+                        />
+                      </div>
+                    </FormulaTooltip>
+                    <FormulaTooltip
+                      variables={{
+                        'Q_{\\text{app}}': variableExplanations['Q_app'],
+                        'C_{\\text{prev}}': variableExplanations['C_prev'],
+                        'N_{\\text{app}}': variableExplanations['N_app'],
+                        'P_{\\text{app}}': variableExplanations['P_app'],
+                      }}
+                    >
+                      <div className="mt-2 border-gray-300 text-xxs">
+                        <BlockMath
+                          math={`
                         \\begin{aligned}
                         &Q_{\\text{app}} \\approx \\underbrace{C_{\\text{prev}}}_{${estimatedDate.details.modelVariables.C_prev.toFixed()}} + \\underbrace{N_{\\text{app}}}_{${estimatedDate.details.modelVariables.N_app.toFixed()}} - \\underbrace{P_{\\text{app}}}_{${estimatedDate.details.modelVariables.P_app.toFixed()}} \\\\
                         \\end{aligned}
                       `}
-                      />
-                    </div>
-                  </FormulaTooltip>
-                </div>
+                        />
+                      </div>
+                    </FormulaTooltip>
+                  </div>
                 )}
               </div>
             )}

--- a/src/components/common/IconTooltip.tsx
+++ b/src/components/common/IconTooltip.tsx
@@ -1,0 +1,73 @@
+// src/components/common/IconTooltip.tsx
+import { useRef, useState } from 'react';
+
+import type React from 'react';
+import {
+  arrow,
+  autoUpdate,
+  flip,
+  FloatingArrow,
+  FloatingPortal,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+
+interface IconTooltipProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+export const IconTooltip: React.FC<IconTooltipProps> = ({ label, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null);
+  const arrowRef = useRef(null);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: 'bottom',
+    whileElementsMounted: autoUpdate,
+    elements: { reference: referenceElement },
+    middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 }), arrow({ element: arrowRef })],
+  });
+
+  const hover = useHover(context, { delay: { open: 300, close: 50 } });
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: 'tooltip' });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([hover, dismiss, role]);
+
+  return (
+    <>
+      <span
+        ref={(node) => {
+          setReferenceElement(node);
+          refs.setReference(node);
+        }}
+        {...getReferenceProps()}
+      >
+        {children}
+      </span>
+
+      {isOpen && (
+        <FloatingPortal>
+          <div
+            ref={refs.setFloating}
+            style={{ ...floatingStyles, zIndex: 999 }}
+            {...getFloatingProps()}
+            className="floating-tooltip"
+            data-status="open"
+          >
+            {label}
+            <FloatingArrow ref={arrowRef} context={context} className="fill-gray-600 dark:fill-gray-300" />
+          </div>
+        </FloatingPortal>
+      )}
+    </>
+  );
+};

--- a/src/utils/__tests__/urlApplicationDetails.test.ts
+++ b/src/utils/__tests__/urlApplicationDetails.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { getApplicationDetailsFromParams, hasPermalinkParams } from '../urlApplicationDetails';
+
+describe('hasPermalinkParams', () => {
+  it('returns false when no permalink params are present', () => {
+    expect(hasPermalinkParams(new URLSearchParams(''))).toBe(false);
+    expect(hasPermalinkParams(new URLSearchParams('unrelated=1'))).toBe(false);
+  });
+
+  it('returns true when any single permalink param is present', () => {
+    expect(hasPermalinkParams(new URLSearchParams('bureau=1'))).toBe(true);
+    expect(hasPermalinkParams(new URLSearchParams('type=60'))).toBe(true);
+    expect(hasPermalinkParams(new URLSearchParams('applicationDate=2025-01-01'))).toBe(true);
+  });
+});
+
+describe('getApplicationDetailsFromParams', () => {
+  it('defaults every field to an empty string when the URL has no params', () => {
+    expect(getApplicationDetailsFromParams(new URLSearchParams(''))).toEqual({
+      bureau: '',
+      type: '',
+      applicationDate: '',
+    });
+  });
+
+  it('passes through a fully valid permalink', () => {
+    const params = new URLSearchParams({
+      bureau: '101170',
+      type: '60',
+      applicationDate: '2025-01-15',
+    });
+
+    expect(getApplicationDetailsFromParams(params)).toEqual({
+      bureau: '101170',
+      type: '60',
+      applicationDate: '2025-01-15',
+    });
+  });
+
+  it('drops a bureau that is not a known non-airport bureau', () => {
+    const params = new URLSearchParams({ bureau: 'not-a-real-bureau', type: '60', applicationDate: '2025-01-15' });
+
+    expect(getApplicationDetailsFromParams(params).bureau).toBe('');
+  });
+
+  it('drops an application type that is unknown or the "all" placeholder', () => {
+    expect(getApplicationDetailsFromParams(new URLSearchParams({ type: 'all' })).type).toBe('');
+    expect(getApplicationDetailsFromParams(new URLSearchParams({ type: 'not-a-type' })).type).toBe('');
+  });
+
+  it('drops a malformed or unparsable application date', () => {
+    expect(
+      getApplicationDetailsFromParams(new URLSearchParams({ applicationDate: 'not-a-date' })).applicationDate
+    ).toBe('');
+    expect(
+      getApplicationDetailsFromParams(new URLSearchParams({ applicationDate: '2025/01/15' })).applicationDate
+    ).toBe('');
+  });
+});

--- a/src/utils/urlApplicationDetails.ts
+++ b/src/utils/urlApplicationDetails.ts
@@ -1,0 +1,37 @@
+// src/utils/urlApplicationDetails.ts
+import { applicationOptions } from '../constants/applicationOptions';
+import { nonAirportBureaus } from './getBureauData';
+
+export interface ApplicationDetails {
+  bureau: string;
+  type: string;
+  applicationDate: string;
+}
+
+const PERMALINK_PARAM_KEYS = ['bureau', 'type', 'applicationDate'] as const;
+
+const isValidBureau = (value: string): boolean => nonAirportBureaus.some((bureau) => bureau.value === value);
+
+const isValidType = (value: string): boolean =>
+  value !== 'all' && applicationOptions.some((option) => option.value === value);
+
+const isValidApplicationDate = (value: string): boolean =>
+  /^\d{4}-\d{2}-\d{2}$/.test(value) && !isNaN(new Date(value).getTime());
+
+// True when the URL carries at least one recognized permalink param, regardless of validity.
+export const hasPermalinkParams = (searchParams: URLSearchParams): boolean =>
+  PERMALINK_PARAM_KEYS.some((key) => searchParams.has(key));
+
+// Reads permalink params from the URL, dropping any value that doesn't match a real
+// bureau/type/date so an invalid or tampered link can't leave the estimator in a broken state.
+export const getApplicationDetailsFromParams = (searchParams: URLSearchParams): ApplicationDetails => {
+  const bureau = searchParams.get('bureau') ?? '';
+  const type = searchParams.get('type') ?? '';
+  const applicationDate = searchParams.get('applicationDate') ?? '';
+
+  return {
+    bureau: isValidBureau(bureau) ? bureau : '',
+    type: isValidType(type) ? type : '',
+    applicationDate: isValidApplicationDate(applicationDate) ? applicationDate : '',
+  };
+};


### PR DESCRIPTION
## Summary
Reimplements the permalink-to-estimator feature originally proposed in #43 by @hemangandhi, with review feedback applied. Since #43's branch lives on a personal fork this session can't push to, the reworked version is opened here as its own PR, superseding #43.

- Estimator bureau/type/applicationDate are synced with URL query params (`?bureau=...&type=...&applicationDate=...`) so a filled-out estimate can be shared via a permalink.
- A "Permalink to these filters" button updates the URL and copies the shareable link to the clipboard.
- The desktop estimator panel only auto-expands when the URL actually carries permalink params — the default (collapsed) is otherwise unchanged for regular visitors.
- URL-sourced `bureau`/`type`/`applicationDate` values are validated against the known bureau list, application types, and date format (`src/utils/urlApplicationDetails.ts`) before being applied, so a malformed or hand-edited link can't leave the form in a broken/mismatched state.
- The share button only writes params that have an actual selected value, instead of padding the URL with empty ones for partially-filled forms.
- Bumped `package.json` to `0.7.0` (minor) since this is a genuine new feature.

## Test plan
- [x] `npm run lint` (next lint) — clean
- [x] `npm test` (vitest) — 12/12 passing, including new unit tests for `urlApplicationDetails` in `src/utils/__tests__/urlApplicationDetails.test.ts`
- [x] `npm run build` (static export) — builds successfully
- [x] Manual smoke test of the permalink flow in a browser

Closes #43 (superseded).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MpacktiiWMFUpg8MmruNYe)_