### PR TITLE
Add changelog modal sourced from CHANGELOG.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ cython_debug/
 .idea
 /public/datastore/**
 /src/buildInfo.js
+/public/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Japan Immigration Bureaus Statistics Dashboard are do
 
 ## 2026-07
 
+### Added
+
+- **v0.6.2**: Added a Changelog modal, opened from the version link in the header, sourced from this file.
+
 ### Fixed
 
 - Corrected an issue where aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) could briefly report inflated processing figures when a branch office (e.g. Kobe) hadn't yet published its data for a period — that period is now treated as unpublished instead of silently "correcting" itself a day later. ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,113 +6,185 @@ All notable changes to the Japan Immigration Bureaus Statistics Dashboard are do
 
 ### Added
 
-- **v0.6.2**: Added a Changelog modal, opened from the version link in the header, sourced from this file.
+- **v0.6.2**: Changelog modal, opened from the version link in the header, sourced from this file.
 
 ### Fixed
 
-- Corrected an issue where aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) could briefly report inflated processing figures when a branch office (e.g. Kobe) hadn't yet published its data for a period. `getCorrectedValue` now flags a period as incomplete when any branch is missing, and `transformData` skips that data point entirely rather than falling back to the inflated raw total — the month is treated as "not yet published" instead of silently "correcting" itself a day later. Added Vitest regression tests for the aggregation fix and a characterization test documenting the estimator's separate, legitimate sensitivity to newly published monthly rates. ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
+- Fixed aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) briefly reporting inflated processing figures when a branch office's data lagged ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
+  - `getCorrectedValue` now flags a period as incomplete when any branch office (e.g. Kobe) hasn't published yet
+  - `transformData` skips incomplete periods instead of falling back to the inflated raw total
+  - Added Vitest regression tests for the aggregation fix
+  - Added a characterization test for the estimator's separate, legitimate sensitivity to newly published rates
 
 ## 2026-06
 
 ### Changed
 
-- Upgraded `next` from 15.5.11 → 15.5.19 (resolving 16 Dependabot alerts) and `postcss` from 8.5.6 → 8.5.15, syncing `@next/third-parties`, `eslint-config-next`, and `@next/eslint-plugin-next` to match. Triaged the remaining Next.js CVEs (middleware bypass, server-component DoS, image-optimization/SSRF issues) as non-applicable since the project builds via `output: 'export'` — a static SPA with no Next.js server runtime in production — and dismissed several transitive dev-only advisories (`lodash` via `@nivo/treemap`, `flatted`, `minimatch`, `picomatch`) with no available upstream fix. ([#42](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/42))
+- Upgraded `next` 15.5.11 → 15.5.19 and `postcss` 8.5.6 → 8.5.15 ([#42](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/42))
+  - Resolved 16 Dependabot alerts on Next.js and 1 on PostCSS
+  - Synced `@next/third-parties`, `eslint-config-next`, and `@next/eslint-plugin-next` to match
+  - Triaged remaining Next.js CVEs as non-applicable, since the static export has no server runtime in production
+  - Dismissed transitive dev-only advisories (`lodash`, `flatted`, `minimatch`, `picomatch`) with no upstream fix available
 
 ## 2026-03
 
 ### Fixed
 
-- Fixed the automated Data Watcher workflow so a run more than 7 days after the last one no longer mistakes an expired GitHub Actions cache for "new data" and triggers a spurious rebuild. The root cause was the 23rd–28th schedule leaving a ~25-day gap between runs that reliably exceeded the 7-day cache TTL, so a missing `prev-` file on the first run of the month was misread as a change. The schedule now runs daily (eliminating the gap and catching mid-month e-Stat corrections), a cache miss now routes through the no-changes path (`changes_detected=false`) instead of falsely triggering a build, and the cache-refresh step switched from a hash-based key to a date-based key (`estat-data-YYYYMMDD`) with a cleanup step so refreshes always create a fresh entry instead of silently no-oping. ([#41](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/41))
+- Fixed spurious rebuilds caused by Data Watcher cache expiration ([#41](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/41))
+  - The 23rd–28th schedule left a ~25-day gap between runs that reliably exceeded the 7-day cache TTL
+  - Switched the schedule to run daily, eliminating the gap
+  - A cache miss now routes through the no-changes path instead of falsely triggering a build
+  - Cache-refresh key switched from hash-based to date-based (`estat-data-YYYYMMDD`), with a cleanup step
 
 ## 2026-02
 
 ### Added
 
-- Environment-aware logger (`src/utils/logger.ts`) that suppresses console output in production builds. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Environment-aware logger that suppresses console output in production builds (`src/utils/logger.ts`) ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ### Changed
 
 - **v0.6.1** released with the changes below.
-- Sizeable code-quality and architecture refactor: enabled TypeScript's `noImplicitAny` and replaced all explicit `any` types with proper types; extracted theme handling into a `ThemeContext`, extracted `DesktopLayout`, `MobileLayout`, and `ActiveChart` components out of `App.tsx` (which shrank from 209 lines of markup to a thin composition layer), and added an `ErrorBoundary`; centralized data filtering into a shared hook instead of filtering per-chart, memoized chart options, lazy-loaded KaTeX, and pre-calculated prefecture colors for the choropleth map; added proper `fetch` cleanup via `AbortController`; introduced `STATUS_CODES` and a shared `StatCard` component. Also fixed the bar chart's Y-axis scaling for the dual-axis (processed/queued) overlay. ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36), [#37](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/37))
-- Overhauled the README: added an Automated Data Updates section, an Architecture & Code Quality section, expanded Contributing guidelines, License/Acknowledgments sections, and documented the full tech stack including the use of Claude Code for AI-assisted development. ([#38](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/38))
-- Migrated all tooltip implementations from Tippy.js to FloatingUI (`@floating-ui/react`) for better TypeScript support, active maintenance, and performance. Added reusable `useTooltip` and `useFollowCursorTooltip` hooks; migrated `StatCard` tooltips (with mobile touch support), the `GeographicDistributionChart` prefecture/bureau map markers (follow-cursor behavior), and `FormulaTooltip` (using a singleton pattern for variable explanations); updated associated CSS and removed the Tippy-specific dependency and styles. ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
+- Refactored for type safety and architecture ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36), [#37](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/37))
+  - Enabled TypeScript's `noImplicitAny` and replaced all explicit `any` types
+  - Extracted `ThemeContext`, `DesktopLayout`, `MobileLayout`, and `ActiveChart` out of `App.tsx`
+  - Added an `ErrorBoundary`
+  - Centralized data filtering into a shared hook instead of filtering per-chart
+  - Memoized chart options, lazy-loaded KaTeX, and pre-calculated prefecture colors
+  - Added proper `fetch` cleanup via `AbortController`
+  - Introduced `STATUS_CODES` and a shared `StatCard` component
+  - Fixed the bar chart's Y-axis scaling for the dual-axis overlay
+- Overhauled the README ([#38](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/38))
+  - Added an Automated Data Updates section
+  - Added an Architecture & Code Quality section
+  - Expanded the Contributing guidelines
+  - Added License and Acknowledgments sections
+  - Documented the full tech stack, including the use of Claude Code
+- Migrated tooltips from Tippy.js to FloatingUI ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
+  - Added reusable `useTooltip` and `useFollowCursorTooltip` hooks
+  - Migrated `StatCard` tooltips, with mobile touch support
+  - Migrated the choropleth map's prefecture/bureau tooltips to follow-cursor behavior
+  - Migrated `FormulaTooltip` to a singleton pattern
+  - Removed the `@tippyjs/react` dependency
 
 ### Fixed
 
-- Filter selection now respects each chart's supported filter types, instead of leaking a bureau/type filter to charts that don't support it. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Filter selection now respects each chart's supported filter types ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ### Security
 
-- Pinned `d3-color` to `^3.1.0` to address [CVE-2024-41235](https://github.com/advisories/GHSA-36jr-mh4h-2g58). ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Pinned `d3-color` to `^3.1.0` for [CVE-2024-41235](https://github.com/advisories/GHSA-36jr-mh4h-2g58) ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ## 2025-12
 
 ### Added
 
-- Automated the Data Watcher GitHub Actions workflow: added a daily cron schedule (`5 1 23-28 * *`, 1:05 AM UTC / 10:05 AM JST) targeting the 25th e-Stat release date with buffer days for weekends/holidays; used `continue-on-error` plus an explicit "mark workflow as successful" step so a "no changes" result no longer fails the run; added UTC/JST execution timestamps, a previous-vs-current `SURVEY_DATE` comparison, and a GitHub Actions step summary; and added a cache-refresh step to prevent the 7-day cache TTL from expiring during quiet periods. ([#33](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/33))
+- Automated the Data Watcher GitHub Actions workflow ([#33](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/33))
+  - Added a daily cron schedule during the e-Stat release window
+  - "No changes" no longer fails the workflow run
+  - Added UTC/JST execution timestamps and a step summary
+  - Added a cache-refresh step to prevent TTL expiration during quiet periods
 
 ## 2025-10
 
 ### Changed
 
-- **v0.5.2**: Renamed the Tokyo bureau to Shinagawa for clarity (since Yokohama is also a branch of Tokyo's Regional Office), added the Kobe Branch Office as its own distinct entity rather than folding it into Osaka's totals, and refreshed prefectural population metrics using 2024 statistics.
+- **v0.5.2**: Bureau and prefectural data refinements
+  - Renamed the Tokyo bureau to Shinagawa for clarity
+  - Added the Kobe Branch Office as its own distinct entity
+  - Refreshed prefectural population metrics with 2024 statistics
 
 ### Fixed
 
-- **v0.5.1**: Corrected duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus, caused by e-Stat publishing branch-office totals that were already aggregated into their parent regional bureau's figures without it being accounted for. Added a new `correctBureauAggregates.ts` utility to deaggregate these values where necessary, validated against a random sample of months and conditions on e-Stat. Reported by a Reddit user (u/TheBipolarTurtle). ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
+- **v0.5.1**: Fixed duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
+  - e-Stat branch-office totals were already folded into their parent bureau's published figures
+  - Added `correctBureauAggregates.ts` to deaggregate the values
+  - Reported by a Reddit user (u/TheBipolarTurtle)
 
 ## 2025-05
 
 ### Changed
 
-- **v0.4.4**: Renamed estimation variables for consistency (`predictedProcessed` → `estimatedProcessed`, `P_proc` → `E_proc`), removed the deprecated `minMonths`/`maxBackwardMonths` constants, and switched average processing-rate calculations to a rolling window of the most recent 6 months of available data for more accurate estimates on bureaus with significant backlogs. Reworked carryover calculation logic to use status code `100000` for totals, replaced "historical" with "available" in tooltip/UI copy for clarity, reintroduced the formula/calculation display for past-due applications, and added the missing `@types/react-katex` devDependency. ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
-- **v0.4.5**: Verbiage-only patch.
+- **v0.4.4**: Estimation logic and naming cleanup ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
+  - Renamed `predictedProcessed` → `estimatedProcessed` and `P_proc` → `E_proc`
+  - Removed the deprecated `minMonths`/`maxBackwardMonths` constants
+  - Average processing rates now use a rolling window of the most recent 6 months
+  - Reworked carryover calculation logic to use status code `100000`
+  - Reintroduced the formula/calculation display for past-due applications
+- **v0.4.5**: Verbiage-only patch
 
 ## 2025-04
 
 ### Added
 
-- **v0.4.1**: Migrated the project from Create React App to Next.js and began converting the codebase to TypeScript. Introduced the `src/app/[[...slug]]` route structure (`layout.tsx`, `client.tsx`, `page.tsx`) replacing the old `index.html`/`index.js` entrypoints, a new reusable `LoadingSpinner` component, and a new `.eslintrc.js`. Renamed `tailwind.config.js` to `.ts`, added `next.config.ts`, moved the e-Stat API ID to an environment variable in the build workflow, restructured image/icon asset locations, and removed deprecated CRA-era files (`manifest.json`, the old `BureauDistributionTreemap` component, etc.). Also fixed a formula calculation/display discrepancy and tooltip/legend issues in charts uncovered during the migration. ([#23](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/23))
+- **v0.4.1**: Migrated the project from Create React App to Next.js ([#23](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/23))
+  - Began converting the codebase to TypeScript
+  - Introduced the `src/app/[[...slug]]` route structure, replacing `index.html`/`index.js`
+  - Added a new reusable `LoadingSpinner` component
+  - Removed deprecated CRA-era files
+  - Moved the e-Stat API ID into an environment variable
 
 ### Fixed
 
-- **v0.4.2**: Simplified the estimation formula by removing the redundant `Q_adj`/`Delta_net` variables inherited from the original prototype, folding their purpose directly into the `C_prev` calculation, and removing an unintended loop in the adjustment calculations that produced abnormal results when application dates shifted across a month boundary — estimates now follow a more linear, predictable pattern. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
-- **v0.4.3**: Fixed `confirmedProcessed` not being excluded from the `estimatedProcessed` pool, which was causing double-counting.
+- **v0.4.2**: Simplified the estimation formula ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
+  - Removed the redundant `Q_adj`/`Delta_net` variables inherited from the original prototype
+  - Removed an unintended loop that caused abnormal results at month boundaries
+  - Estimates now follow a more linear, predictable pattern
+- **v0.4.3**: Fixed `confirmedProcessed` not being excluded from the estimated-processed pool, which caused double-counting
 
 ## 2025-03
 
 ### Changed
 
-- **v0.3.2** patch release, alongside Data Watcher workflow maintenance (`watcher.yaml` updated twice).
+- **v0.3.2** patch release
+- Data Watcher workflow maintenance
 
 ## 2025-02
 
 ### Added
 
-- **v0.3.1** — a large feature release:
-  - **Advanced calculation model**: refined monthly/daily estimate logic with UTC normalization, a hybrid system blending real data with predictive averages, new `totalProcessed`/`totalDays` metrics, and LaTeX-rendered formulas for readability.
-  - **New charts**: `BureauDistributionRingChart`, `BureauPerformanceBubbleChart`, `MonthlyRadarChart`, and `CategorySubmissionsLineChart`, plus an interactive choropleth map of Japan (`GeographicDistributionChart`, built on `react-simple-maps` with a new `japan.topo.json` topology dataset) for visualizing prefectural and bureau data.
-  - **UI**: redesigned Estimation Cards with dynamic rendering and better responsiveness, a unified layout with collapsible panels, and new reusable `FilterInput` and `FormulaTooltip` components.
-  - **Tooltips**: replaced native/basic tooltips with Tippy.js, and added KaTeX-powered tooltips for formula explanations.
-  - **Workflows**: added a new `watcher.yaml` for hourly e-Stat API polling with caching and automatic cleanup, plus least-privilege permissions, JSON validation, and error-handling hardening in the build workflow.
-  - **Accessibility**: added aria-labels to buttons/links for screen-reader support toward Lighthouse audit compliance.
-  - Downgraded React/ReactDOM to v18 for KaTeX compatibility.
+- **v0.3.1**: Advanced Calculation Model and Data Visualization ([#21](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/21))
+  - Refined monthly/daily estimate logic with UTC normalization
+  - Introduced a hybrid model blending real data with predictive averages
+  - Added `totalProcessed`/`totalDays` metrics
+  - Rendered formulas with LaTeX for readability
+  - Added `BureauDistributionRingChart`, `BureauPerformanceBubbleChart`, `MonthlyRadarChart`, and `CategorySubmissionsLineChart`
+  - Added an interactive choropleth map of Japan (`react-simple-maps` + `japan.topo.json`)
+  - Added reusable `FilterInput` and `FormulaTooltip` components
+  - Replaced basic tooltips with Tippy.js; added KaTeX-powered formula tooltips
+  - Added an hourly e-Stat polling workflow with caching
+  - Hardened the build workflow's permissions and error handling
+  - Added aria-labels for screen-reader accessibility
 
 ### Changed
 
-- Consolidated helper functions, removed deprecated logic and unused variables, and reformatted the codebase with Prettier.
+- Consolidated helper functions and removed deprecated/unused code
 
 ## 2025-01
 
 ### Added
 
-- Initial public release, building up to **v0.1.0**: the original Create React App-based dashboard with a stacked bar chart, Estimation Card, Filter Panel, and Stats Summary, backed by an e-Stat data pipeline and a GitHub Actions build/deploy workflow. Early iteration added calculation logic accounting for queue position and total applications processed to date, a collapsible Estimation Card with a details pane showing the underlying formula (with independently toggleable filter/detail visibility), additional predictive logic and chart view options, and moved processed-application data onto a second y-axis on the bar chart to visualize it as a share of the existing application pool.
-- **v0.1.3**: Build-time version/build-date display (via the new `react-build-info` package) baked into the header, and a README status badge.
-- Issue templates, an MIT `LICENSE`, and a `FUNDING.yml`.
-- **v0.2.1**: A comprehensive UI overhaul — mobile-first responsive design using Tailwind's native breakpoints, dark mode support with a toggle switch, a drawer variant of the Estimation Card for mobile, tooltips for mobile StatCards, and a Google Analytics tag for traffic analytics. Extracted common styles into dedicated CSS files, removed duplicate classes and deprecated media queries, moved estimation calculation logic into a dedicated utility file, and integrated Prettier with the Tailwind plugin for consistent formatting. ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
-- **v0.2.2**: Follow-up UI polish across `index.html`, `EstimationCard`, `StatsSummary`, and global styles.
+- Initial dashboard: stacked bar chart, Estimation Card, Filter Panel, and Stats Summary
+  - Backed by an e-Stat data pipeline and a GitHub Actions build/deploy workflow
+  - Added calculation logic accounting for queue position and applications processed to date
+  - Added a collapsible Estimation Card with a details pane showing the underlying formula
+  - Added additional predictive logic and chart view options
+  - Moved processed-application data onto a second y-axis on the bar chart
+- **v0.1.3**: Build-time version/build-date display baked into the header
+  - Added a README status badge
+- Added issue templates, an MIT `LICENSE`, and a `FUNDING.yml`
+- **v0.2.1**: Responsive design and dark mode ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
+  - Mobile-first responsive design using Tailwind's native breakpoints
+  - Dark mode support with a toggle switch
+  - Drawer variant of the Estimation Card for mobile
+  - Tooltips for mobile StatCards
+  - Google Analytics traffic tag
+  - Extracted shared styles into dedicated CSS files
+  - Integrated Prettier with the Tailwind plugin
+- **v0.2.2**: Follow-up UI polish across `index.html`, `EstimationCard`, `StatsSummary`, and global styles
 
 ### Fixed
 
-- **v0.1.1**: Added placeholder text to the month input as a temporary guide for Safari (macOS) users, since that browser doesn't natively support the `month` input type at this time; and fixed "Last Updated" in the nav bar so it bakes in at build time instead of incorrectly updating on every page render.
-- **v0.1.2**: The Estimation Card no longer returns early with no details shown when an application's completion date is already past due. ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))
+- **v0.1.1**: Safari month-input placeholder text
+  - "Last Updated" now bakes in at build time instead of updating on every page render
+- **v0.1.2**: The Estimation Card no longer returns early with no details shown when a completion date is already past due ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to the Japan Immigration Bureaus Statistics Dashboard are documented in this file, grouped by month. The dashboard's header shows the currently deployed version.
+
+## 2026-07
+
+### Fixed
+
+- Corrected an issue where aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) could briefly report inflated processing figures when a branch office (e.g. Kobe) hadn't yet published its data for a period — that period is now treated as unpublished instead of silently "correcting" itself a day later. ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
+
+## 2026-06
+
+### Changed
+
+- Upgraded Next.js to 15.5.19 and PostCSS to 8.5.15, resolving Dependabot alerts and hardening the development server. ([#42](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/42))
+
+## 2026-03
+
+### Fixed
+
+- Fixed the automated Data Watcher workflow so a run more than 7 days after the last one no longer mistakes an expired GitHub Actions cache for "new data" and triggers a spurious rebuild; the watcher now runs daily instead of only the 23rd–28th. ([#41](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/41))
+
+## 2026-02
+
+### Added
+
+- Environment-aware logger that suppresses console output in production builds. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+
+### Changed
+
+- **v0.6.1** released with the changes below.
+- Migrated tooltip implementations from Tippy.js to FloatingUI across all components for better TypeScript support, active maintenance, and performance. ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
+- Refactored for type safety by enabling `noImplicitAny`, extracted `ThemeContext`, `DesktopLayout`/`MobileLayout` components, and an `ErrorBoundary`; centralized data filtering and memoized chart options for performance. ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36))
+- Updated the README with Automated Data Updates, Architecture & Code Quality, and expanded Contributing sections. ([#38](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/38))
+
+### Fixed
+
+- Filter selection now respects each chart's supported filter types instead of leaking filters to charts that don't support them. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+
+### Security
+
+- Pinned `d3-color` to `^3.1.0` to address [CVE-2024-41235](https://github.com/advisories/GHSA-36jr-mh4h-2g58). ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+
+## 2025-12
+
+### Added
+
+- Automated the Data Watcher GitHub Actions workflow with a daily schedule during the e-Stat release window, clearer success/failure handling, and a cache-refresh step to avoid cache expiration between runs. ([#33](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/33))
+
+## 2025-10
+
+### Changed
+
+- **v0.5.2**: Renamed the Tokyo bureau to Shinagawa for clarity, added the Kobe Branch Office as its own entity (previously folded into Osaka's totals), and refreshed prefectural population statistics for 2024.
+
+### Fixed
+
+- **v0.5.1**: Corrected duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus caused by aggregated e-Stat data that hadn't previously been accounted for. ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
+
+## 2025-05
+
+### Changed
+
+- **v0.4.4**: Renamed estimation variables for consistency (`predictedProcessed` → `estimatedProcessed`, `P_proc` → `E_proc`), switched average processing rates to a rolling most-recent-6-months window, and refreshed related documentation. ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
+- **v0.4.5**: Verbiage updates.
+
+## 2025-04
+
+### Added
+
+- **v0.4.1**: Migrated the project from Create React App to Next.js and began the conversion to TypeScript. ([#23](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/23))
+
+### Fixed
+
+- **v0.4.2**: Simplified the estimation formula, removing redundant `Q_adj`/`Delta_net` variables and an unintended loop that produced abnormal results when application dates shifted across a month boundary. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
+- **v0.4.3**: Fixed `confirmedProcessed` not being excluded from the estimated-processed pool, which caused double-counting.
+
+## 2025-03
+
+### Changed
+
+- **v0.3.2** patch release and Data Watcher workflow maintenance.
+
+## 2025-02
+
+### Added
+
+- **v0.3.1**: Introduced an advanced calculation model with hybrid real/predictive estimates and UTC-normalized daily estimation, new charts (Bureau Performance Bubble, Monthly Radar, Category Submissions Line), and an interactive choropleth map of Japan. ([#21](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/21))
+
+### Changed
+
+- Replaced basic tooltips with Tippy.js and added KaTeX-powered formula tooltips.
+
+## 2025-01
+
+### Added
+
+- Initial public releases, v0.1.0 through v0.2.2: core dashboard with bar chart and estimation card, collapsible estimation panel with LaTeX-rendered formulas, mobile-first responsive design, dark mode, and a build version/date display baked in at build time. ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
+
+### Fixed
+
+- **v0.1.2**: The Estimation Card no longer returns early with no details shown when an application's completion date is already past due. ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Added
 
-- **v0.6.2**: Added a Changelog modal, opened from the version link in the header.
+- **v0.8.0**: Added a Changelog modal, opened from the version link in the header.
+- **v0.7.0**: Added a permalink button to the Processing Time Estimator —
+  - Share a filled-out estimate (bureau, application type, and date) via a copyable link
+  - Opening a permalink automatically expands the estimator with those filters pre-filled
+  ([#45](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/45))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,190 +1,93 @@
 # Changelog
 
-All notable changes to the Japan Immigration Bureaus Statistics Dashboard are documented in this file, grouped by month. The dashboard's header shows the currently deployed version.
+All notable user-facing changes to the Japan Immigration Bureaus Statistics Dashboard are documented in this file, grouped by month. The dashboard's header shows the currently deployed version.
 
 ## 2026-07
 
 ### Added
 
-- **v0.6.2**: Changelog modal, opened from the version link in the header, sourced from this file.
+- **v0.6.2**: Added a Changelog modal, opened from the version link in the header.
 
 ### Fixed
 
-- Fixed aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) briefly reporting inflated processing figures when a branch office's data lagged ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
-  - `getCorrectedValue` now flags a period as incomplete when any branch office (e.g. Kobe) hasn't published yet
-  - `transformData` skips incomplete periods instead of falling back to the inflated raw total
-  - Added Vitest regression tests for the aggregation fix
-  - Added a characterization test for the estimator's separate, legitimate sensitivity to newly published rates
-
-## 2026-06
-
-### Changed
-
-- Upgraded `next` 15.5.11 → 15.5.19 and `postcss` 8.5.6 → 8.5.15 ([#42](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/42))
-  - Resolved 16 Dependabot alerts on Next.js and 1 on PostCSS
-  - Synced `@next/third-parties`, `eslint-config-next`, and `@next/eslint-plugin-next` to match
-  - Triaged remaining Next.js CVEs as non-applicable, since the static export has no server runtime in production
-  - Dismissed transitive dev-only advisories (`lodash`, `flatted`, `minimatch`, `picomatch`) with no upstream fix available
-
-## 2026-03
-
-### Fixed
-
-- Fixed spurious rebuilds caused by Data Watcher cache expiration ([#41](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/41))
-  - The 23rd–28th schedule left a ~25-day gap between runs that reliably exceeded the 7-day cache TTL
-  - Switched the schedule to run daily, eliminating the gap
-  - A cache miss now routes through the no-changes path instead of falsely triggering a build
-  - Cache-refresh key switched from hash-based to date-based (`estat-data-YYYYMMDD`), with a cleanup step
+- Fixed aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) briefly showing inflated processing-time estimates when a branch office's data hadn't been published yet for the period. ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
 
 ## 2026-02
 
 ### Added
 
-- Environment-aware logger that suppresses console output in production builds (`src/utils/logger.ts`) ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Added a friendly error screen instead of a blank page if the app hits an unexpected error. ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36))
 
 ### Changed
 
-- **v0.6.1** released with the changes below.
-- Refactored for type safety and architecture ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36), [#37](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/37))
-  - Enabled TypeScript's `noImplicitAny` and replaced all explicit `any` types
-  - Extracted `ThemeContext`, `DesktopLayout`, `MobileLayout`, and `ActiveChart` out of `App.tsx`
-  - Added an `ErrorBoundary`
-  - Centralized data filtering into a shared hook instead of filtering per-chart
-  - Memoized chart options, lazy-loaded KaTeX, and pre-calculated prefecture colors
-  - Added proper `fetch` cleanup via `AbortController`
-  - Introduced `STATUS_CODES` and a shared `StatCard` component
-  - Fixed the bar chart's Y-axis scaling for the dual-axis overlay
-- Overhauled the README ([#38](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/38))
-  - Added an Automated Data Updates section
-  - Added an Architecture & Code Quality section
-  - Expanded the Contributing guidelines
-  - Added License and Acknowledgments sections
-  - Documented the full tech stack, including the use of Claude Code
-- Migrated tooltips from Tippy.js to FloatingUI ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
-  - Added reusable `useTooltip` and `useFollowCursorTooltip` hooks
-  - Migrated `StatCard` tooltips, with mobile touch support
-  - Migrated the choropleth map's prefecture/bureau tooltips to follow-cursor behavior
-  - Migrated `FormulaTooltip` to a singleton pattern
-  - Removed the `@tippyjs/react` dependency
+- Improved tooltips: added touch support on mobile, and map tooltips now follow the cursor. ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
 
 ### Fixed
 
-- Filter selection now respects each chart's supported filter types ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Fixed the intake/processing bar chart's Y-axis scaling when overlaying processed applications. ([#37](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/37))
+- Filter selections now only apply to charts that actually support them, instead of leaking to charts they shouldn't affect. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ### Security
 
-- Pinned `d3-color` to `^3.1.0` for [CVE-2024-41235](https://github.com/advisories/GHSA-36jr-mh4h-2g58) ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
-
-## 2025-12
-
-### Added
-
-- Automated the Data Watcher GitHub Actions workflow ([#33](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/33))
-  - Added a daily cron schedule during the e-Stat release window
-  - "No changes" no longer fails the workflow run
-  - Added UTC/JST execution timestamps and a step summary
-  - Added a cache-refresh step to prevent TTL expiration during quiet periods
+- Patched a known vulnerability ([CVE-2024-41235](https://github.com/advisories/GHSA-36jr-mh4h-2g58)) in a charting dependency. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ## 2025-10
 
 ### Changed
 
-- **v0.5.2**: Bureau and prefectural data refinements
-  - Renamed the Tokyo bureau to Shinagawa for clarity
-  - Added the Kobe Branch Office as its own distinct entity
-  - Refreshed prefectural population metrics with 2024 statistics
+- **v0.5.2**: Renamed the Tokyo bureau to Shinagawa for clarity, and added the Kobe Branch Office as its own entity instead of folding it into Osaka's totals.
+- Refreshed prefectural population statistics with 2024 data.
 
 ### Fixed
 
-- **v0.5.1**: Fixed duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
-  - e-Stat branch-office totals were already folded into their parent bureau's published figures
-  - Added `correctBureauAggregates.ts` to deaggregate the values
-  - Reported by a Reddit user (u/TheBipolarTurtle)
+- **v0.5.1**: Fixed duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus, caused by e-Stat publishing branch totals that were already counted in the parent bureau's figures. ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
 
 ## 2025-05
 
 ### Changed
 
-- **v0.4.4**: Estimation logic and naming cleanup ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
-  - Renamed `predictedProcessed` → `estimatedProcessed` and `P_proc` → `E_proc`
-  - Removed the deprecated `minMonths`/`maxBackwardMonths` constants
-  - Average processing rates now use a rolling window of the most recent 6 months
-  - Reworked carryover calculation logic to use status code `100000`
-  - Reintroduced the formula/calculation display for past-due applications
-- **v0.4.5**: Verbiage-only patch
+- **v0.4.4**: Average processing-rate estimates now use the most recent 6 months of data, for better accuracy. ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
+- Reintroduced the formula/calculation details for applications already past their estimated completion date.
 
 ## 2025-04
 
-### Added
-
-- **v0.4.1**: Migrated the project from Create React App to Next.js ([#23](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/23))
-  - Began converting the codebase to TypeScript
-  - Introduced the `src/app/[[...slug]]` route structure, replacing `index.html`/`index.js`
-  - Added a new reusable `LoadingSpinner` component
-  - Removed deprecated CRA-era files
-  - Moved the e-Stat API ID into an environment variable
-
 ### Fixed
 
-- **v0.4.2**: Simplified the estimation formula ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
-  - Removed the redundant `Q_adj`/`Delta_net` variables inherited from the original prototype
-  - Removed an unintended loop that caused abnormal results at month boundaries
-  - Estimates now follow a more linear, predictable pattern
-- **v0.4.3**: Fixed `confirmedProcessed` not being excluded from the estimated-processed pool, which caused double-counting
+- **v0.4.2**: Simplified the estimation formula, fixing abnormal results that could occur when an application date shifted across a month boundary. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
+- **v0.4.3**: Fixed a double-counting bug in the processed-applications estimate.
 
 ## 2025-03
 
-### Changed
+### Fixed
 
-- **v0.3.2** patch release
-- Data Watcher workflow maintenance
+- **v0.3.2**: Fixed a discrepancy between the estimated completion date shown and the formula details displayed for the same application.
 
 ## 2025-02
 
 ### Added
 
-- **v0.3.1**: Advanced Calculation Model and Data Visualization ([#21](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/21))
-  - Refined monthly/daily estimate logic with UTC normalization
-  - Introduced a hybrid model blending real data with predictive averages
-  - Added `totalProcessed`/`totalDays` metrics
+- **v0.3.1**: A large feature release —
+  - Refined the calculation model for more accurate monthly and daily estimates
+  - Added four new charts: Bureau Distribution Ring, Bureau Performance Bubble, Monthly Radar, and Category Submissions
+  - Added an interactive choropleth map of Japan for visualizing bureau and prefecture data
   - Rendered formulas with LaTeX for readability
-  - Added `BureauDistributionRingChart`, `BureauPerformanceBubbleChart`, `MonthlyRadarChart`, and `CategorySubmissionsLineChart`
-  - Added an interactive choropleth map of Japan (`react-simple-maps` + `japan.topo.json`)
-  - Added reusable `FilterInput` and `FormulaTooltip` components
-  - Replaced basic tooltips with Tippy.js; added KaTeX-powered formula tooltips
-  - Added an hourly e-Stat polling workflow with caching
-  - Hardened the build workflow's permissions and error handling
-  - Added aria-labels for screen-reader accessibility
-
-### Changed
-
-- Consolidated helper functions and removed deprecated/unused code
+  - Upgraded tooltips, including formula explanations
+  - Improved accessibility for screen readers
+  ([#21](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/21))
 
 ## 2025-01
 
 ### Added
 
-- Initial dashboard: stacked bar chart, Estimation Card, Filter Panel, and Stats Summary
-  - Backed by an e-Stat data pipeline and a GitHub Actions build/deploy workflow
-  - Added calculation logic accounting for queue position and applications processed to date
-  - Added a collapsible Estimation Card with a details pane showing the underlying formula
-  - Added additional predictive logic and chart view options
-  - Moved processed-application data onto a second y-axis on the bar chart
-- **v0.1.3**: Build-time version/build-date display baked into the header
-  - Added a README status badge
-- Added issue templates, an MIT `LICENSE`, and a `FUNDING.yml`
-- **v0.2.1**: Responsive design and dark mode ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
-  - Mobile-first responsive design using Tailwind's native breakpoints
-  - Dark mode support with a toggle switch
-  - Drawer variant of the Estimation Card for mobile
-  - Tooltips for mobile StatCards
-  - Google Analytics traffic tag
-  - Extracted shared styles into dedicated CSS files
-  - Integrated Prettier with the Tailwind plugin
-- **v0.2.2**: Follow-up UI polish across `index.html`, `EstimationCard`, `StatsSummary`, and global styles
+- Initial launch: application-intake bar chart, Estimation Card, Filter Panel, and Stats Summary, with a collapsible details pane showing the underlying formula.
+- **v0.2.1**: Mobile-first responsive design and dark mode —
+  - Mobile-friendly layout with native breakpoints
+  - Dark mode with a toggle switch
+  - Drawer-style Estimation Card and tooltips on mobile
+  ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
+- **v0.2.2**: Follow-up UI polish.
 
 ### Fixed
 
-- **v0.1.1**: Safari month-input placeholder text
-  - "Last Updated" now bakes in at build time instead of updating on every page render
-- **v0.1.2**: The Estimation Card no longer returns early with no details shown when a completion date is already past due ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))
+- **v0.1.1**: Added guidance text for the month picker on Safari (macOS), which didn't natively support that input type at the time; fixed the displayed "Last Updated" date so it reflects the actual build instead of updating every time the page loads.
+- **v0.1.2**: The Estimation Card no longer shows no details when an application's completion date is already past due. ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,36 +10,36 @@ All notable changes to the Japan Immigration Bureaus Statistics Dashboard are do
 
 ### Fixed
 
-- Corrected an issue where aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) could briefly report inflated processing figures when a branch office (e.g. Kobe) hadn't yet published its data for a period — that period is now treated as unpublished instead of silently "correcting" itself a day later. ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
+- Corrected an issue where aggregate bureaus (Osaka, Fukuoka, Nagoya, Shinagawa) could briefly report inflated processing figures when a branch office (e.g. Kobe) hadn't yet published its data for a period. `getCorrectedValue` now flags a period as incomplete when any branch is missing, and `transformData` skips that data point entirely rather than falling back to the inflated raw total — the month is treated as "not yet published" instead of silently "correcting" itself a day later. Added Vitest regression tests for the aggregation fix and a characterization test documenting the estimator's separate, legitimate sensitivity to newly published monthly rates. ([#44](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/44))
 
 ## 2026-06
 
 ### Changed
 
-- Upgraded Next.js to 15.5.19 and PostCSS to 8.5.15, resolving Dependabot alerts and hardening the development server. ([#42](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/42))
+- Upgraded `next` from 15.5.11 → 15.5.19 (resolving 16 Dependabot alerts) and `postcss` from 8.5.6 → 8.5.15, syncing `@next/third-parties`, `eslint-config-next`, and `@next/eslint-plugin-next` to match. Triaged the remaining Next.js CVEs (middleware bypass, server-component DoS, image-optimization/SSRF issues) as non-applicable since the project builds via `output: 'export'` — a static SPA with no Next.js server runtime in production — and dismissed several transitive dev-only advisories (`lodash` via `@nivo/treemap`, `flatted`, `minimatch`, `picomatch`) with no available upstream fix. ([#42](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/42))
 
 ## 2026-03
 
 ### Fixed
 
-- Fixed the automated Data Watcher workflow so a run more than 7 days after the last one no longer mistakes an expired GitHub Actions cache for "new data" and triggers a spurious rebuild; the watcher now runs daily instead of only the 23rd–28th. ([#41](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/41))
+- Fixed the automated Data Watcher workflow so a run more than 7 days after the last one no longer mistakes an expired GitHub Actions cache for "new data" and triggers a spurious rebuild. The root cause was the 23rd–28th schedule leaving a ~25-day gap between runs that reliably exceeded the 7-day cache TTL, so a missing `prev-` file on the first run of the month was misread as a change. The schedule now runs daily (eliminating the gap and catching mid-month e-Stat corrections), a cache miss now routes through the no-changes path (`changes_detected=false`) instead of falsely triggering a build, and the cache-refresh step switched from a hash-based key to a date-based key (`estat-data-YYYYMMDD`) with a cleanup step so refreshes always create a fresh entry instead of silently no-oping. ([#41](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/41))
 
 ## 2026-02
 
 ### Added
 
-- Environment-aware logger that suppresses console output in production builds. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Environment-aware logger (`src/utils/logger.ts`) that suppresses console output in production builds. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ### Changed
 
 - **v0.6.1** released with the changes below.
-- Migrated tooltip implementations from Tippy.js to FloatingUI across all components for better TypeScript support, active maintenance, and performance. ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
-- Refactored for type safety by enabling `noImplicitAny`, extracted `ThemeContext`, `DesktopLayout`/`MobileLayout` components, and an `ErrorBoundary`; centralized data filtering and memoized chart options for performance. ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36))
-- Updated the README with Automated Data Updates, Architecture & Code Quality, and expanded Contributing sections. ([#38](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/38))
+- Sizeable code-quality and architecture refactor: enabled TypeScript's `noImplicitAny` and replaced all explicit `any` types with proper types; extracted theme handling into a `ThemeContext`, extracted `DesktopLayout`, `MobileLayout`, and `ActiveChart` components out of `App.tsx` (which shrank from 209 lines of markup to a thin composition layer), and added an `ErrorBoundary`; centralized data filtering into a shared hook instead of filtering per-chart, memoized chart options, lazy-loaded KaTeX, and pre-calculated prefecture colors for the choropleth map; added proper `fetch` cleanup via `AbortController`; introduced `STATUS_CODES` and a shared `StatCard` component. Also fixed the bar chart's Y-axis scaling for the dual-axis (processed/queued) overlay. ([#36](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/36), [#37](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/37))
+- Overhauled the README: added an Automated Data Updates section, an Architecture & Code Quality section, expanded Contributing guidelines, License/Acknowledgments sections, and documented the full tech stack including the use of Claude Code for AI-assisted development. ([#38](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/38))
+- Migrated all tooltip implementations from Tippy.js to FloatingUI (`@floating-ui/react`) for better TypeScript support, active maintenance, and performance. Added reusable `useTooltip` and `useFollowCursorTooltip` hooks; migrated `StatCard` tooltips (with mobile touch support), the `GeographicDistributionChart` prefecture/bureau map markers (follow-cursor behavior), and `FormulaTooltip` (using a singleton pattern for variable explanations); updated associated CSS and removed the Tippy-specific dependency and styles. ([#39](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/39))
 
 ### Fixed
 
-- Filter selection now respects each chart's supported filter types instead of leaking filters to charts that don't support them. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
+- Filter selection now respects each chart's supported filter types, instead of leaking a bureau/type filter to charts that don't support it. ([#40](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/40))
 
 ### Security
 
@@ -49,58 +49,70 @@ All notable changes to the Japan Immigration Bureaus Statistics Dashboard are do
 
 ### Added
 
-- Automated the Data Watcher GitHub Actions workflow with a daily schedule during the e-Stat release window, clearer success/failure handling, and a cache-refresh step to avoid cache expiration between runs. ([#33](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/33))
+- Automated the Data Watcher GitHub Actions workflow: added a daily cron schedule (`5 1 23-28 * *`, 1:05 AM UTC / 10:05 AM JST) targeting the 25th e-Stat release date with buffer days for weekends/holidays; used `continue-on-error` plus an explicit "mark workflow as successful" step so a "no changes" result no longer fails the run; added UTC/JST execution timestamps, a previous-vs-current `SURVEY_DATE` comparison, and a GitHub Actions step summary; and added a cache-refresh step to prevent the 7-day cache TTL from expiring during quiet periods. ([#33](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/33))
 
 ## 2025-10
 
 ### Changed
 
-- **v0.5.2**: Renamed the Tokyo bureau to Shinagawa for clarity, added the Kobe Branch Office as its own entity (previously folded into Osaka's totals), and refreshed prefectural population statistics for 2024.
+- **v0.5.2**: Renamed the Tokyo bureau to Shinagawa for clarity (since Yokohama is also a branch of Tokyo's Regional Office), added the Kobe Branch Office as its own distinct entity rather than folding it into Osaka's totals, and refreshed prefectural population metrics using 2024 statistics.
 
 ### Fixed
 
-- **v0.5.1**: Corrected duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus caused by aggregated e-Stat data that hadn't previously been accounted for. ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
+- **v0.5.1**: Corrected duplicated application figures in the Tokyo, Osaka, Nagoya, and Fukuoka bureaus, caused by e-Stat publishing branch-office totals that were already aggregated into their parent regional bureau's figures without it being accounted for. Added a new `correctBureauAggregates.ts` utility to deaggregate these values where necessary, validated against a random sample of months and conditions on e-Stat. Reported by a Reddit user (u/TheBipolarTurtle). ([#31](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/31))
 
 ## 2025-05
 
 ### Changed
 
-- **v0.4.4**: Renamed estimation variables for consistency (`predictedProcessed` → `estimatedProcessed`, `P_proc` → `E_proc`), switched average processing rates to a rolling most-recent-6-months window, and refreshed related documentation. ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
-- **v0.4.5**: Verbiage updates.
+- **v0.4.4**: Renamed estimation variables for consistency (`predictedProcessed` → `estimatedProcessed`, `P_proc` → `E_proc`), removed the deprecated `minMonths`/`maxBackwardMonths` constants, and switched average processing-rate calculations to a rolling window of the most recent 6 months of available data for more accurate estimates on bureaus with significant backlogs. Reworked carryover calculation logic to use status code `100000` for totals, replaced "historical" with "available" in tooltip/UI copy for clarity, reintroduced the formula/calculation display for past-due applications, and added the missing `@types/react-katex` devDependency. ([#28](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/28))
+- **v0.4.5**: Verbiage-only patch.
 
 ## 2025-04
 
 ### Added
 
-- **v0.4.1**: Migrated the project from Create React App to Next.js and began the conversion to TypeScript. ([#23](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/23))
+- **v0.4.1**: Migrated the project from Create React App to Next.js and began converting the codebase to TypeScript. Introduced the `src/app/[[...slug]]` route structure (`layout.tsx`, `client.tsx`, `page.tsx`) replacing the old `index.html`/`index.js` entrypoints, a new reusable `LoadingSpinner` component, and a new `.eslintrc.js`. Renamed `tailwind.config.js` to `.ts`, added `next.config.ts`, moved the e-Stat API ID to an environment variable in the build workflow, restructured image/icon asset locations, and removed deprecated CRA-era files (`manifest.json`, the old `BureauDistributionTreemap` component, etc.). Also fixed a formula calculation/display discrepancy and tooltip/legend issues in charts uncovered during the migration. ([#23](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/23))
 
 ### Fixed
 
-- **v0.4.2**: Simplified the estimation formula, removing redundant `Q_adj`/`Delta_net` variables and an unintended loop that produced abnormal results when application dates shifted across a month boundary. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
-- **v0.4.3**: Fixed `confirmedProcessed` not being excluded from the estimated-processed pool, which caused double-counting.
+- **v0.4.2**: Simplified the estimation formula by removing the redundant `Q_adj`/`Delta_net` variables inherited from the original prototype, folding their purpose directly into the `C_prev` calculation, and removing an unintended loop in the adjustment calculations that produced abnormal results when application dates shifted across a month boundary — estimates now follow a more linear, predictable pattern. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
+- **v0.4.3**: Fixed `confirmedProcessed` not being excluded from the `estimatedProcessed` pool, which was causing double-counting.
 
 ## 2025-03
 
 ### Changed
 
-- **v0.3.2** patch release and Data Watcher workflow maintenance.
+- **v0.3.2** patch release, alongside Data Watcher workflow maintenance (`watcher.yaml` updated twice).
 
 ## 2025-02
 
 ### Added
 
-- **v0.3.1**: Introduced an advanced calculation model with hybrid real/predictive estimates and UTC-normalized daily estimation, new charts (Bureau Performance Bubble, Monthly Radar, Category Submissions Line), and an interactive choropleth map of Japan. ([#21](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/21))
+- **v0.3.1** — a large feature release:
+  - **Advanced calculation model**: refined monthly/daily estimate logic with UTC normalization, a hybrid system blending real data with predictive averages, new `totalProcessed`/`totalDays` metrics, and LaTeX-rendered formulas for readability.
+  - **New charts**: `BureauDistributionRingChart`, `BureauPerformanceBubbleChart`, `MonthlyRadarChart`, and `CategorySubmissionsLineChart`, plus an interactive choropleth map of Japan (`GeographicDistributionChart`, built on `react-simple-maps` with a new `japan.topo.json` topology dataset) for visualizing prefectural and bureau data.
+  - **UI**: redesigned Estimation Cards with dynamic rendering and better responsiveness, a unified layout with collapsible panels, and new reusable `FilterInput` and `FormulaTooltip` components.
+  - **Tooltips**: replaced native/basic tooltips with Tippy.js, and added KaTeX-powered tooltips for formula explanations.
+  - **Workflows**: added a new `watcher.yaml` for hourly e-Stat API polling with caching and automatic cleanup, plus least-privilege permissions, JSON validation, and error-handling hardening in the build workflow.
+  - **Accessibility**: added aria-labels to buttons/links for screen-reader support toward Lighthouse audit compliance.
+  - Downgraded React/ReactDOM to v18 for KaTeX compatibility.
 
 ### Changed
 
-- Replaced basic tooltips with Tippy.js and added KaTeX-powered formula tooltips.
+- Consolidated helper functions, removed deprecated logic and unused variables, and reformatted the codebase with Prettier.
 
 ## 2025-01
 
 ### Added
 
-- Initial public releases, v0.1.0 through v0.2.2: core dashboard with bar chart and estimation card, collapsible estimation panel with LaTeX-rendered formulas, mobile-first responsive design, dark mode, and a build version/date display baked in at build time. ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
+- Initial public release, building up to **v0.1.0**: the original Create React App-based dashboard with a stacked bar chart, Estimation Card, Filter Panel, and Stats Summary, backed by an e-Stat data pipeline and a GitHub Actions build/deploy workflow. Early iteration added calculation logic accounting for queue position and total applications processed to date, a collapsible Estimation Card with a details pane showing the underlying formula (with independently toggleable filter/detail visibility), additional predictive logic and chart view options, and moved processed-application data onto a second y-axis on the bar chart to visualize it as a share of the existing application pool.
+- **v0.1.3**: Build-time version/build-date display (via the new `react-build-info` package) baked into the header, and a README status badge.
+- Issue templates, an MIT `LICENSE`, and a `FUNDING.yml`.
+- **v0.2.1**: A comprehensive UI overhaul — mobile-first responsive design using Tailwind's native breakpoints, dark mode support with a toggle switch, a drawer variant of the Estimation Card for mobile, tooltips for mobile StatCards, and a Google Analytics tag for traffic analytics. Extracted common styles into dedicated CSS files, removed duplicate classes and deprecated media queries, moved estimation calculation logic into a dedicated utility file, and integrated Prettier with the Tailwind plugin for consistent formatting. ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
+- **v0.2.2**: Follow-up UI polish across `index.html`, `EstimationCard`, `StatsSummary`, and global styles.
 
 ### Fixed
 
+- **v0.1.1**: Added placeholder text to the month input as a temporary guide for Safari (macOS) users, since that browser doesn't natively support the `month` input type at this time; and fixed "Last Updated" in the nav bar so it bakes in at build time instead of incorrectly updating on every page render.
 - **v0.1.2**: The Estimation Card no longer returns early with no details shown when an application's completion date is already past due. ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Japan Immigration Statistics Dashboard
-[![Version](https://img.shields.io/badge/version-0.6.1-blue.svg)](https://github.com/RetroHazard/JP_Immigration_Dashboard/releases)
+[![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)](https://github.com/RetroHazard/JP_Immigration_Dashboard/releases)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp_immigration_dashboard",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
@@ -86,7 +86,8 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -424,7 +425,8 @@
       "optional": true,
       "engines": {
         "node": ">=18"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
@@ -446,7 +448,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.34.5",
@@ -468,7 +471,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
@@ -484,7 +488,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.2.4",
@@ -500,7 +505,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.2.4",
@@ -516,7 +522,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
@@ -532,7 +539,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
@@ -548,7 +556,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
@@ -564,7 +573,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
@@ -580,7 +590,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
@@ -596,7 +607,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
@@ -612,7 +624,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
@@ -628,7 +641,8 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.34.5",
@@ -650,7 +664,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.34.5",
@@ -672,7 +687,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.34.5",
@@ -694,7 +710,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.34.5",
@@ -716,7 +733,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.5",
@@ -738,7 +756,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
@@ -760,7 +779,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.34.5",
@@ -782,7 +802,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
@@ -804,7 +825,8 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.34.5",
@@ -823,7 +845,8 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
@@ -842,7 +865,8 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-win32-ia32": {
       "version": "0.34.5",
@@ -861,7 +885,8 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.34.5",
@@ -880,7 +905,8 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -962,7 +988,8 @@
       "resolved": "https://registry.npmjs.org/null/-/null-2.0.0.tgz",
       "integrity": "sha512-CVSXPeB7Af0Sku7w8N8EKkgcwvQ6wGNfs6bly419A/q6dpIwzaHIk+65+La2g80ml21uxVXQo8xReTMI2WEYbA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "dev": true
     },
     "node_modules/@next/swc-darwin-x64": {
       "version": "15.5.19",
@@ -978,7 +1005,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
       "version": "15.5.19",
@@ -994,7 +1022,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/swc-linux-arm64-musl": {
       "version": "15.5.19",
@@ -1010,7 +1039,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "15.5.19",
@@ -1026,7 +1056,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/swc-linux-x64-musl": {
       "version": "15.5.19",
@@ -1042,7 +1073,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
       "version": "15.5.19",
@@ -1058,7 +1090,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "15.5.19",
@@ -1074,7 +1107,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/@next/third-parties": {
       "version": "15.5.19",
@@ -1650,7 +1684,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/d3-geo": {
       "version": "2.0.7",
@@ -1666,7 +1701,8 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.11.tgz",
       "integrity": "sha512-lnQiU7jV+Gyk9oQYk0GGYccuexmQPTp08E0+4BidgFdiJivjEvf+esPSdZqCZ2C7UwTWejWpqetVaU8A+eX3FA==",
-      "license": "MIT"
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/d3-interpolate": {
       "version": "2.0.5",
@@ -1689,7 +1725,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
@@ -1698,13 +1735,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
-      }
+      },
+      "dev": true
     },
     "node_modules/@types/d3-scale-chromatic": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/d3-selection": {
       "version": "2.0.5",
@@ -1720,13 +1759,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
-      }
+      },
+      "dev": true
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/d3-zoom": {
       "version": "2.0.7",
@@ -1788,7 +1829,8 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "19.0.10",
@@ -3577,11 +3619,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "dev": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -6204,7 +6246,8 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "dev": true
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
@@ -7254,14 +7297,14 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7355,7 +7398,8 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
+      },
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   },
   "scripts": {
     "lint": "next lint",
-    "start": "react-build-info && next build && npx serve@latest ./build",
-    "build": "react-build-info && next build",
-    "dev": "react-build-info && next dev --turbopack",
+    "start": "react-build-info && node scripts/sync-changelog.js && next build && npx serve@latest ./build",
+    "build": "react-build-info && node scripts/sync-changelog.js && next build",
+    "dev": "react-build-info && node scripts/sync-changelog.js && next dev --turbopack",
     "test": "vitest run",
     "postinstall": "node -e \"(process.env.npm_command != 'ci') && require('lockfile-shaker/lib/bin.js')\""
   },

--- a/scripts/sync-changelog.js
+++ b/scripts/sync-changelog.js
@@ -1,0 +1,11 @@
+// scripts/sync-changelog.js
+// Copies the repo-root CHANGELOG.md into public/ so it's served as a static
+// asset by the exported SPA (see next.config.ts `output: 'export'`) and can
+// be fetched at runtime by the Changelog modal.
+const fs = require('fs');
+const path = require('path');
+
+const source = path.join(__dirname, '..', 'CHANGELOG.md');
+const destination = path.join(__dirname, '..', 'public', 'CHANGELOG.md');
+
+fs.copyFileSync(source, destination);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import type React from 'react';
 import { Icon } from '@iconify/react';
 
+import { ChangelogModal } from './components/ChangelogModal';
 import { CHART_COMPONENTS } from './components/common/ChartComponents';
 import { LoadingSpinner } from './components/common/LoadingSpinner';
 import { DesktopLayout } from './components/layouts/DesktopLayout';
@@ -34,6 +35,7 @@ const App: React.FC = () => {
   // Only auto-expand the estimator when a permalink has pre-filled it; otherwise stay collapsed by default.
   const [isEstimationExpanded, setIsEstimationExpanded] = useState(() => hasPermalinkParams(searchParams));
   const [activeChartIndex, setActiveChartIndex] = useState(0);
+  const [isChangelogOpen, setIsChangelogOpen] = useState(false);
 
   // Get current chart's filter configuration
   const currentChartFilters = CHART_COMPONENTS[activeChartIndex].filters;
@@ -98,7 +100,14 @@ const App: React.FC = () => {
             </div>
             <div className="flex items-center gap-1 lg:gap-5">
               <div className="flex-col-end">
-                <span className="build-info">Version: {buildInfo.buildVersion}</span>
+                <button
+                  onClick={() => setIsChangelogOpen(true)}
+                  aria-label="View changelog"
+                  className="build-info hyperlink flex items-center gap-1"
+                >
+                  <Icon icon="ph:clock-counter-clockwise" className="size-3 lg:size-3.5" />
+                  Version: {buildInfo.buildVersion}
+                </button>
                 <span className="build-info">Last Updated:</span>
                 <span className="build-info">
                   {new Date(buildInfo.buildDate).toLocaleDateString('en-US', {
@@ -182,6 +191,8 @@ const App: React.FC = () => {
           </div>
         </div>
       </footer>
+
+      <ChangelogModal isOpen={isChangelogOpen} onClose={() => setIsChangelogOpen(false)} />
     </div>
   );
 };

--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -1,0 +1,76 @@
+// src/components/ChangelogModal.tsx
+import { useEffect, useState } from 'react';
+
+import type React from 'react';
+import { Icon } from '@iconify/react';
+
+import { logger } from '../utils/logger';
+import { ChangelogContent } from '../utils/renderChangelog';
+
+interface ChangelogModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ChangelogModal: React.FC<ChangelogModalProps> = ({ isOpen, onClose }) => {
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || markdown !== null) return;
+
+    fetch('/CHANGELOG.md')
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.text();
+      })
+      .then(setMarkdown)
+      .catch((fetchError: unknown) => {
+        logger.error('Error loading changelog:', fetchError);
+        setError('Unable to load the changelog.');
+      });
+  }, [isOpen, markdown]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="flex max-h-[80vh] w-full max-w-lg flex-col rounded-lg bg-white shadow-xl dark:bg-gray-700"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Changelog"
+      >
+        <div className="flex items-center justify-between border-b p-4 dark:border-gray-600">
+          <h2 className="section-title">Changelog</h2>
+          <button onClick={onClose} aria-label="Close changelog" className="theme-toggle-icon">
+            <Icon icon="ph:x-bold" className="size-5 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100" />
+          </button>
+        </div>
+        <div className="card-content overflow-y-auto p-4">
+          {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+          {!error && markdown === null && (
+            <p className="text-sm text-gray-500 dark:text-gray-300">Loading...</p>
+          )}
+          {!error && markdown !== null && <ChangelogContent markdown={markdown} />}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/utils/renderChangelog.tsx
+++ b/src/utils/renderChangelog.tsx
@@ -1,0 +1,108 @@
+// src/utils/renderChangelog.tsx
+import type React from 'react';
+
+// Renders inline markdown spans: **bold**, `code`, and [text](url) links.
+const renderInline = (text: string, keyPrefix: string): React.ReactNode[] => {
+  const pattern = /\*\*(.+?)\*\*|`(.+?)`|\[([^\]]+)]\(([^)]+)\)/g;
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let index = 0;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+
+    const [full, bold, code, linkText, linkHref] = match;
+    const key = `${keyPrefix}-${index++}`;
+
+    if (bold !== undefined) {
+      nodes.push(
+        <strong key={key} className="font-semibold text-gray-800 dark:text-gray-100">
+          {bold}
+        </strong>,
+      );
+    } else if (code !== undefined) {
+      nodes.push(
+        <code key={key} className="rounded bg-gray-100 px-1 py-0.5 text-xxs dark:bg-gray-600 sm:text-xs">
+          {code}
+        </code>,
+      );
+    } else if (linkText !== undefined && linkHref !== undefined) {
+      nodes.push(
+        <a key={key} href={linkHref} className="hyperlink" target="_blank" rel="noreferrer">
+          {linkText}
+        </a>,
+      );
+    } else {
+      nodes.push(full);
+    }
+
+    lastIndex = pattern.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
+};
+
+interface ChangelogMonth {
+  heading: string;
+  sections: { heading: string; items: string[] }[];
+}
+
+// Parses a CHANGELOG.md whose body is a flat list of `## YYYY-MM` month
+// headings, each containing `### Category` subheadings with `- ` bullets.
+export const parseChangelog = (markdown: string): ChangelogMonth[] => {
+  const months: ChangelogMonth[] = [];
+  let currentMonth: ChangelogMonth | null = null;
+  let currentSection: { heading: string; items: string[] } | null = null;
+
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.trimEnd();
+
+    if (line.startsWith('## ')) {
+      currentMonth = { heading: line.slice(3).trim(), sections: [] };
+      currentSection = null;
+      months.push(currentMonth);
+    } else if (line.startsWith('### ') && currentMonth) {
+      currentSection = { heading: line.slice(4).trim(), items: [] };
+      currentMonth.sections.push(currentSection);
+    } else if (line.startsWith('- ') && currentSection) {
+      currentSection.items.push(line.slice(2).trim());
+    }
+  }
+
+  return months;
+};
+
+export const ChangelogContent: React.FC<{ markdown: string }> = ({ markdown }) => {
+  const months = parseChangelog(markdown);
+
+  return (
+    <div className="space-y-6">
+      {months.map((month) => (
+        <div key={month.heading}>
+          <h3 className="text-sm font-bold text-gray-800 dark:text-gray-100 sm:text-base">{month.heading}</h3>
+          <div className="mt-2 space-y-3">
+            {month.sections.map((section) => (
+              <div key={section.heading}>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-300 sm:text-sm">
+                  {section.heading}
+                </h4>
+                <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-gray-700 dark:text-gray-300 sm:text-sm">
+                  {section.items.map((item, index) => (
+                    <li key={`${section.heading}-${index}`}>{renderInline(item, `${section.heading}-${index}`)}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/utils/renderChangelog.tsx
+++ b/src/utils/renderChangelog.tsx
@@ -49,17 +49,30 @@ const renderInline = (text: string, keyPrefix: string): React.ReactNode[] => {
   return nodes;
 };
 
+interface ChangelogItem {
+  text: string;
+  children: string[];
+}
+
+interface ChangelogSection {
+  heading: string;
+  items: ChangelogItem[];
+}
+
 interface ChangelogMonth {
   heading: string;
-  sections: { heading: string; items: string[] }[];
+  sections: ChangelogSection[];
 }
 
 // Parses a CHANGELOG.md whose body is a flat list of `## YYYY-MM` month
 // headings, each containing `### Category` subheadings with `- ` bullets.
+// A bullet indented by two spaces (`  - `) nests under the preceding
+// top-level bullet, so one release/PR can list each change as its own line.
 export const parseChangelog = (markdown: string): ChangelogMonth[] => {
   const months: ChangelogMonth[] = [];
   let currentMonth: ChangelogMonth | null = null;
-  let currentSection: { heading: string; items: string[] } | null = null;
+  let currentSection: ChangelogSection | null = null;
+  let currentItem: ChangelogItem | null = null;
 
   for (const rawLine of markdown.split('\n')) {
     const line = rawLine.trimEnd();
@@ -67,12 +80,17 @@ export const parseChangelog = (markdown: string): ChangelogMonth[] => {
     if (line.startsWith('## ')) {
       currentMonth = { heading: line.slice(3).trim(), sections: [] };
       currentSection = null;
+      currentItem = null;
       months.push(currentMonth);
     } else if (line.startsWith('### ') && currentMonth) {
       currentSection = { heading: line.slice(4).trim(), items: [] };
+      currentItem = null;
       currentMonth.sections.push(currentSection);
+    } else if (/^ {2}- /.test(line) && currentItem) {
+      currentItem.children.push(line.trim().slice(2).trim());
     } else if (line.startsWith('- ') && currentSection) {
-      currentSection.items.push(line.slice(2).trim());
+      currentItem = { text: line.slice(2).trim(), children: [] };
+      currentSection.items.push(currentItem);
     }
   }
 
@@ -93,10 +111,23 @@ export const ChangelogContent: React.FC<{ markdown: string }> = ({ markdown }) =
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-300 sm:text-sm">
                   {section.heading}
                 </h4>
-                <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-gray-700 dark:text-gray-300 sm:text-sm">
-                  {section.items.map((item, index) => (
-                    <li key={`${section.heading}-${index}`}>{renderInline(item, `${section.heading}-${index}`)}</li>
-                  ))}
+                <ul className="mt-1 list-disc space-y-1.5 pl-5 text-xs text-gray-700 dark:text-gray-300 sm:text-sm">
+                  {section.items.map((item, index) => {
+                    const itemKey = `${section.heading}-${index}`;
+                    return (
+                      <li key={itemKey}>
+                        {renderInline(item.text, itemKey)}
+                        {item.children.length > 0 && (
+                          <ul className="mt-1 list-[circle] space-y-1 pl-5 text-gray-600 dark:text-gray-400">
+                            {item.children.map((child, childIndex) => {
+                              const childKey = `${itemKey}-${childIndex}`;
+                              return <li key={childKey}>{renderInline(child, childKey)}</li>;
+                            })}
+                          </ul>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             ))}


### PR DESCRIPTION
Adds a repo-root CHANGELOG.md summarizing the full commit/PR history
month-by-month, and a modal on the dashboard (opened via the version
link in the header) that fetches and renders it at runtime. A small
build script copies CHANGELOG.md into public/ so the static export
can serve it, keeping the root file as the single source of truth.