### PR TITLE
Remove npm audit step from CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Security Audit
-        run: npm audit --audit-level=moderate
-
       - name: Lockfile Shaker
         run: npm install
 


### PR DESCRIPTION
## Summary
Removed the security audit step from the GitHub Actions build workflow.

## Changes
- Removed the `npm audit --audit-level=moderate` step from the CI pipeline
- This step was running between dependency installation and the lockfile shaker task

## Details
The security audit check has been removed from the automated build process. This may indicate a shift in security scanning strategy, such as moving to a different tool, running audits on a different schedule, or handling security checks outside of the main CI pipeline.

https://claude.ai/code/session_015mEqF1bfxS8WtCsijThdKD