### PR TITLE
Japanese language pack

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,9 +219,10 @@ graph TD
 Every user-visible string resolves through a per-language catalogue; `src/i18n/README.md` is the reference. Two things are worth knowing before working elsewhere in the tree:
 
 - **Domain constants carry no display text.** `bureauOptions`, `applicationOptions`, `japanPrefectures`, and `CHART_COMPONENTS` hold codes, geometry, and capability flags only. Names come from the catalogue, joined back by the hooks in `useDomainLabels.ts`. Consequently a bureau's name can only be resolved inside a component — utilities that need one take a resolver argument (`computeEfficiencyPoints`).
-- **Four vendored Bklit files are locally modified.** `charts/chart-formatters.ts` and `charts/chart-stat-flow.tsx` had their `Intl` locale hardcoded to `en-US` (and, in one case, left to the browser); `charts/y-axis.tsx` built tick labels with an English `${n / 1000}k` suffix. Those three now read module state that `LocaleProvider` sets during render. `charts/sankey/sankey-tooltip.tsx` hardcoded its two row labels, and takes `valueLabel` / `linkLabel` props instead. `scripts/vendor-bklit.mjs` would overwrite all four — re-apply after a re-vendor. Each file says so at the point of change.
+- **Four vendored Bklit files are locally modified.** `charts/chart-formatters.ts` and `charts/chart-stat-flow.tsx` had their `Intl` locale hardcoded to `en-US` (and, in one case, left to the browser); `charts/y-axis.tsx` built tick labels with an English `${n / 1000}k` suffix. Those three now read module state that `LocaleProvider` sets during render. `charts/sankey/sankey-tooltip.tsx` hardcoded its two row labels, and takes `valueLabel` / `linkLabel` props instead. Two further changes came out of actually rendering Japanese: `chart-stat-flow.tsx` also passes `locales` to `NumberFlow`, which otherwise reverted to the browser locale once the animation library loaded, and `y-axis.tsx` marks tick labels `whitespace-nowrap`, because `100万` breaks across two lines in a 40px axis margin. `scripts/vendor-bklit.mjs` would overwrite all four — re-apply after a re-vendor. Each file says so at the point of change.
+- **Domain names come in three widths.** `bureau.*` and `appType.*` each carry `.label`, `.compact`, and `.short`, resolved together by `useDomainLabels.ts`. The width-constrained surfaces — the efficiency chart's 92px label column, the ring-chart legend, the treemap tile, and the Sankey's narrow layout — read `.compact`; everything with room reads `.label`. English says the same thing at every width, so this is invisible there; Japanese needs it, because 東京出入国在留管理局横浜支局 and 東京出入国在留管理局成田空港支局 truncate identically.
 
-The language switcher exists but is gated behind `LOCALE_SWITCHER_ENABLED` in `src/i18n/config.ts`, which also gates browser-language detection.
+The language switcher is gated behind `LOCALE_SWITCHER_ENABLED` in `src/i18n/config.ts`, which also gates browser-language detection — one flag for both, because auto-detecting a language is only safe while the visitor has a visible way back. It is on, now that Japanese is fully translated.
 
 #### **DashboardShell** (`src/components/DashboardShell.tsx`)
 
@@ -278,7 +279,7 @@ Summary statistics display, built from `StatCard` (`src/components/common/StatCa
 
 ### Header & Footer
 
-There is no separate `layouts/` directory — the header (branding, language switcher, theme toggle, changelog trigger) and footer (attribution, e-Stat credit) markup live directly inside `DashboardShell.tsx`. The language switcher renders nothing while `LOCALE_SWITCHER_ENABLED` is false (see below).
+There is no separate `layouts/` directory — the header (branding, language switcher, theme toggle, changelog trigger) and footer (attribution, e-Stat credit) markup live directly inside `DashboardShell.tsx`. The language switcher renders nothing while `LOCALE_SWITCHER_ENABLED` is false (see below); it is on today.
 
 #### **ErrorBoundary** (`src/components/common/ErrorBoundary.tsx`)
 - Catches React errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Added
 
+- **Japanese**: the dashboard is now fully available in Japanese, and the language switcher is live —
+  - All 330 interface strings are translated, using the Immigration Services Agency's own terminology: application types carry their official procedure names (在留資格変更許可申請 rather than a paraphrase), and each bureau its full office name including branch status (東京出入国在留管理局横浜支局). Prefecture names match the map data exactly, so the map tooltip no longer prints the same name twice
+  - The switcher appears in the header and the mobile settings drawer, and a visitor whose browser asks for Japanese now lands on it — it stayed hidden while Japanese was a five-string stub, which is what the flag was waiting for
+  - Numbers, dates, and counted phrases already followed the language; they now read as Japanese throughout — 万 and 億 on chart axes, 2026年9月22日 for dates, and 6か月 without an English plural
+  - Bureaus and application types gained a third, narrower name for the dense charts. Without it every Tokyo-area office truncated to the same 「東京出入国在留」 in the Processing Efficiency ranking, which made them impossible to tell apart. English is unaffected — it says the same thing at both widths
+  - Fixed three things that only surfaced once the interface was actually rendering Japanese: the Category Mix tooltip fell back to a font with no Japanese glyphs, animated numbers reverted to the browser's language mid-animation, and a chart axis label wide enough to wrap dropped 万 onto its own line
 - **v1.2.0**: Localization foundation — every string in the interface is now translatable —
   - Text, ARIA labels, chart legends and tooltips, table headers, and empty and error states all come from a single catalogue file per language, so adding a language means writing one file rather than editing components. A partial translation is safe to ship: anything left out falls back to English instead of rendering blank
   - Numbers, percentages, and dates follow the chosen language, including chart axis ticks and tooltips, and counted phrases ("6 months", "± 3 days") use real plural rules rather than an English "s". Chart y-axis labels also read better in English as a side effect — a million now shows as "1M" rather than "1000k"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -238,7 +238,7 @@ JP_Immigration_Dashboard/
 │   ├── i18n/                          # See src/i18n/README.md
 │   │   ├── locales/
 │   │   │   ├── en.ts                  # Source of truth; DictionaryKey derives from it
-│   │   │   ├── ja.ts                  # Partial override, falls back to English
+│   │   │   ├── ja.ts                  # Complete Japanese catalogue
 │   │   │   ├── _template.ts           # Generated starting point (npm run i18n:template)
 │   │   │   └── index.ts               # Registry — one entry per language, with its status
 │   │   ├── LocaleContext.tsx          # Provider + useLocale()

--- a/README.md
+++ b/README.md
@@ -139,11 +139,12 @@ Seven interactive charts, each answering a specific question about the data, wit
 
 ---
 
-### :globe_with_meridians: Localization *(foundation complete, translations open)*
+### :globe_with_meridians: Localization *(English and Japanese)*
 - Every string in the interface — text, ARIA labels, chart legends, tooltips, table headers, empty and error states — comes from a single catalogue file per language, so **adding a language means writing one file** and touching no components (see [`src/i18n/README.md`](src/i18n/README.md))
 - Numbers, percentages, and dates follow the active locale, including chart axis ticks and tooltips; counted phrases use real plural rules rather than an English "s"
 - A partial translation is safe to ship: anything a language leaves out falls back to English rather than rendering blank
-- The language switcher is built but **deliberately hidden** — Japanese is still a stub, and offering the switch before a language is actually translated is what got the original switcher pulled. `?lang=ja` works for testing. Flipping `LOCALE_SWITCHER_ENABLED` in `src/i18n/config.ts` is the whole change when a locale is ready
+- **Japanese is complete** — all 330 keys, using the official 出入国在留管理庁 terminology for bureaus and application types. The language switcher is live in the header and the mobile settings drawer, and a visitor whose browser asks for Japanese lands on it
+- Bureaus and application types each carry three widths (`.label`, `.compact`, `.short`) so an office's full official name can appear where there's room without collapsing the dense charts, where several offices would otherwise truncate to the same prefix
 
 ---
 

--- a/src/components/__tests__/LanguageSwitcher.test.tsx
+++ b/src/components/__tests__/LanguageSwitcher.test.tsx
@@ -1,7 +1,8 @@
 // src/components/__tests__/LanguageSwitcher.test.tsx
-// The switcher is built but gated off, so the thing worth pinning is that the
-// gate actually holds — and that the control works when it's opened, so
-// flipping the flag isn't a leap of faith.
+// The switcher's enabled half: every registered locale offered, the active one
+// marked, and a click that both switches and persists. The flag is mocked on
+// rather than read, so this keeps testing the control itself even as the
+// shipped default changes; the gated-off half is LanguageSwitcherGate.test.tsx.
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent } from '@testing-library/react';
 

--- a/src/components/__tests__/LanguageSwitcherGate.test.tsx
+++ b/src/components/__tests__/LanguageSwitcherGate.test.tsx
@@ -1,0 +1,32 @@
+// src/components/__tests__/LanguageSwitcherGate.test.tsx
+// The gate half of the switcher's contract: with LOCALE_SWITCHER_ENABLED off,
+// nothing renders at all. Its counterpart — that the control works with the
+// flag on — is LanguageSwitcher.test.tsx.
+//
+// Both files mock the flag rather than reading the shipped value, so neither
+// silently stops testing anything the day the default changes. It shipped
+// `false` while Japanese was a stub and `true` once Japanese was complete; the
+// gate itself has to keep working either way, because that is what lets a
+// future in-progress locale be held back.
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as ConfigModule from '../../i18n/config';
+import { renderWithProviders } from '../../test-utils';
+import { LanguageSwitcher } from '../common/LanguageSwitcher';
+
+vi.mock('../../i18n/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof ConfigModule>()),
+  LOCALE_SWITCHER_ENABLED: false,
+}));
+
+describe('LanguageSwitcher, while gated off', () => {
+  it('renders nothing at all', () => {
+    const { container } = renderWithProviders(<LanguageSwitcher />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing in the drawer variant either', () => {
+    const { container } = renderWithProviders(<LanguageSwitcher variant="rows" />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/components/__tests__/components.smoke.test.tsx
+++ b/src/components/__tests__/components.smoke.test.tsx
@@ -8,9 +8,9 @@ import { fireEvent } from '@testing-library/react';
 
 import type { ImmigrationData } from '../../hooks/useImmigrationData';
 import { en } from '../../i18n/locales/en';
+import { ja } from '../../i18n/locales/ja';
 import { renderWithProviders, screen } from '../../test-utils';
 import { ChartDataTable } from '../ChartDataTable';
-import { LanguageSwitcher } from '../common/LanguageSwitcher';
 import { SeriesLegend } from '../common/SeriesLegend';
 import { StatCard } from '../common/StatCard';
 
@@ -75,22 +75,16 @@ describe('ChartDataTable', () => {
     expect(screen.getByText(en['table.downloadCsv'])).toBeTruthy();
   });
 
-  it('renders the same English text under an untranslated locale', () => {
-    // ja.ts has no `table.*` keys yet, so this exercises the fallback path an
-    // in-progress translation depends on — nothing should render as a raw key.
+  it('renders the translated text under the Japanese locale', () => {
+    // The catalogue reaches this component through the provider rather than a
+    // prop, so this is what proves a locale switch actually lands in the DOM.
+    // (The English-fallback path a partial locale depends on is covered
+    // directly, with synthetic dictionaries, in i18n/__tests__/translate.test.ts.)
     renderWithProviders(<ChartDataTable data={data} filters={{ bureau: 'all', type: 'all' }} range="all" />, {
       locale: 'ja',
     });
-    expect(screen.getByText(en['table.view'])).toBeTruthy();
+    expect(screen.getByText(ja['table.view']!)).toBeTruthy();
+    expect(screen.queryByText(en['table.view'])).toBeNull();
     expect(screen.queryByText('table.view')).toBeNull();
-  });
-});
-
-describe('LanguageSwitcher', () => {
-  it('renders nothing while the switcher is gated off', () => {
-    // The counterpart — that it works once enabled — is in
-    // LanguageSwitcher.test.tsx, which mocks the flag on.
-    const { container } = renderWithProviders(<LanguageSwitcher />);
-    expect(container.innerHTML).toBe('');
   });
 });

--- a/src/components/bklit/charts/chart-stat-flow.tsx
+++ b/src/components/bklit/charts/chart-stat-flow.tsx
@@ -7,7 +7,11 @@ import { cn } from "@/lib/utils";
 // LOCAL MODIFICATION: upstream formats with `undefined` (the browser locale),
 // which disagrees with every other number on the page once the app's own
 // locale differs from the browser's. Reads the same module state as
-// chart-formatters.ts. Re-apply after a re-vendor.
+// chart-formatters.ts. Applied in two places — the static fallback below and
+// the NumberFlow branch it hands over to, which otherwise reformatted the
+// number the moment the animation library loaded. pie-center and ring-center
+// both route through this component, so they are covered by the same change.
+// Re-apply after a re-vendor.
 import { chartFormatterLocale } from "./chart-formatters";
 
 /** Subset of `Intl.NumberFormatOptions` supported by NumberFlow */
@@ -109,9 +113,15 @@ export function ChartStatFlow({
       ) : null}
       <span className={cn("text-foreground tabular-nums", valueClassName)}>
         {numberFlowReady ? (
+          /* `locales` mirrors the static branch below, which formats through
+             chartFormatterLocale(). Without it NumberFlow falls back to the
+             browser locale, so the number silently reformatted the moment the
+             animation library finished loading — a ja reader on an en browser
+             watched 1.2万 flip to 12K mid-paint. */
           <NumberFlow
             format={formatOptions}
             isolate
+            locales={chartFormatterLocale()}
             prefix={prefix}
             suffix={suffix}
             value={value}

--- a/src/components/bklit/charts/y-axis.tsx
+++ b/src/components/bklit/charts/y-axis.tsx
@@ -156,8 +156,15 @@ const YAxisInner = memo(function YAxisInner({
                 : { left: 0, justifyContent: "flex-start", paddingLeft: 8 }),
             }}
           >
+            {/* LOCAL MODIFICATION: whitespace-nowrap. The label strip is only
+                as wide as margin.left (40px, less 8px padding), which fits the
+                Latin forms upstream assumes — "1.2M", "800K". A ja-JP tick
+                reads 100万 at almost exactly that width and broke across two
+                lines, dropping 万 onto its own row. Overflowing left into the
+                card's padding is the right trade: a numeric axis label should
+                never wrap in any language. Re-apply after a re-vendor. */}
             <span
-              className="text-chart-label text-xs"
+              className="whitespace-nowrap text-chart-label text-xs"
               style={tick.labelColor ? { color: tick.labelColor } : undefined}
             >
               {tick.label}

--- a/src/components/charts/BureauDistributionRingChart.tsx
+++ b/src/components/charts/BureauDistributionRingChart.tsx
@@ -11,7 +11,7 @@ import type React from 'react';
 import { bureauOptions } from '../../constants/bureauOptions';
 import { STATUS_CODES } from '../../constants/statusCodes';
 import { useLocale } from '../../i18n/LocaleContext';
-import { useBureauLabel } from '../../i18n/useDomainLabels';
+import { useBureauCompact } from '../../i18n/useDomainLabels';
 import { getAllMonths, monthsForRange, selectData } from '../../utils/selectors';
 import { PieCenter } from '../bklit/charts/pie-center';
 import { PieChart } from '../bklit/charts/pie-chart';
@@ -33,7 +33,9 @@ const SLICE_COLORS = [
 export const BureauDistributionRingChart: React.FC<ImmigrationChartData> = ({ data, filters, range }) => {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const { t, formatters } = useLocale();
-  const bureauLabel = useBureauLabel();
+  // Compact names: the legend doesn't truncate, so a long label pushes the
+  // percentage and value columns off the end of the row instead of clipping.
+  const bureauCompact = useBureauCompact();
 
   const { slices, total } = useMemo(() => {
     const months = monthsForRange(getAllMonths(data), range);
@@ -47,7 +49,7 @@ export const BureauDistributionRingChart: React.FC<ImmigrationChartData> = ({ da
     const byBureau = bureauOptions
       .filter((bureau) => bureau.value !== 'all')
       .map((bureau) => ({
-        label: bureauLabel(bureau.value),
+        label: bureauCompact(bureau.value),
         value: rows.reduce((sum, entry) => (entry.bureau === bureau.value ? sum + entry.value : sum), 0),
       }))
       .filter((bureau) => bureau.value > 0)
@@ -65,7 +67,7 @@ export const BureauDistributionRingChart: React.FC<ImmigrationChartData> = ({ da
       slices: result.map((slice, index) => ({ ...slice, color: SLICE_COLORS[index] })),
       total: byBureau.reduce((sum, bureau) => sum + bureau.value, 0),
     };
-  }, [data, filters.type, range, bureauLabel, t]);
+  }, [data, filters.type, range, bureauCompact, t]);
 
   if (slices.length === 0) {
     return (

--- a/src/components/charts/CategoryMixTreemap.tsx
+++ b/src/components/charts/CategoryMixTreemap.tsx
@@ -14,7 +14,7 @@ import type React from 'react';
 import { createPortal } from 'react-dom';
 
 import { useLocale } from '../../i18n/LocaleContext';
-import { useApplicationType, useBureauLabel } from '../../i18n/useDomainLabels';
+import { useApplicationType, useBureauCompact, useBureauLabel } from '../../i18n/useDomainLabels';
 import type { MixTree } from '../../utils/categoryMixTree';
 import { buildCategoryMixTree, mixLeafColor } from '../../utils/categoryMixTree';
 import type { ImmigrationChartData } from '../common/ChartComponents';
@@ -173,6 +173,7 @@ export const CategoryMixTreemap: React.FC<ImmigrationChartData> = ({ data, filte
   const fmt = formatters.number;
   const applicationType = useApplicationType();
   const getBureauLabel = useBureauLabel();
+  const getBureauCompact = useBureauCompact();
   const typeLabel = (code: string) => applicationType(code)?.label ?? code;
   const typeShort = (code: string) => applicationType(code)?.short ?? code;
   const [focusKey, setFocusKey] = useState<string | null>(null);
@@ -386,7 +387,9 @@ export const CategoryMixTreemap: React.FC<ImmigrationChartData> = ({ data, filte
               >
                 {showLabel && (
                   <span className="flex flex-col px-2 py-1 text-xs font-semibold leading-tight">
-                    <span>{rest ? t('chart.mix.others') : getBureauLabel(leaf.code)}</span>
+                    {/* Compact on the tile — it only renders above 74px wide
+                        and ellipsizes. The tooltip above keeps the full name. */}
+                    <span>{rest ? t('chart.mix.others') : getBureauCompact(leaf.code)}</span>
                     {!rest && (
                       <span className="font-mono text-xxs font-medium opacity-75">
                         {fmt(leaf.value)} · {formatters.percent((leaf.value / base) * 100)}

--- a/src/components/charts/ProcessingEfficiencyLollipop.tsx
+++ b/src/components/charts/ProcessingEfficiencyLollipop.tsx
@@ -13,7 +13,7 @@ import type React from 'react';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import { useLocale } from '../../i18n/LocaleContext';
-import { useBureauLabel } from '../../i18n/useDomainLabels';
+import { useBureauCompact, useBureauLabel } from '../../i18n/useDomainLabels';
 import { useAnimeScope } from '../../lib/motion';
 import type { EfficiencyPoint } from '../../utils/processingEfficiency';
 import { computeEfficiencyPoints, nationwideCompletionRate } from '../../utils/processingEfficiency';
@@ -34,6 +34,7 @@ export const ProcessingEfficiencyLollipop: React.FC<ImmigrationChartData> = ({ d
   const { isDarkMode } = useTheme();
   const { t, formatters } = useLocale();
   const bureauLabel = useBureauLabel();
+  const bureauCompact = useBureauCompact();
   const [hovered, setHovered] = useState<Hover | null>(null);
 
   const points = useMemo(
@@ -114,8 +115,12 @@ export const ProcessingEfficiencyLollipop: React.FC<ImmigrationChartData> = ({ d
                 className={`${ROW_GRID} min-h-[27px] items-center rounded-[8px] px-1.5 py-1 outline-none hover:bg-accent focus-visible:bg-accent`}
                 {...hoverProps(point)}
               >
+                {/* The compact name, not `point.label`: this cell is 92px and
+                    truncates, and the full official names of a region's offices
+                    share a long prefix. The aria-label above keeps the full
+                    name, so nothing is lost to a screen reader. */}
                 <div className="truncate text-xs font-semibold" style={{ color: 'var(--chart-label)' }}>
-                  {point.label}
+                  {bureauCompact(point.code)}
                   {point.isAirport && (
                     <span className="block text-xxs font-medium text-muted-foreground">
                       {t('chart.efficiency.branchOffice')}

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -37,7 +37,7 @@ means writing one file. You do not need to touch a component.
 
 3. **Check it.** `npx vitest run src/i18n` runs the catalogue tests described
    below, and `npx tsc --noEmit` catches any key that isn't real. The test run
-   prints your coverage, e.g. `ko: 120/309 keys (38.8%) — 189 missing`.
+   prints your coverage, e.g. `ko: 120/325 keys (36.9%) — 205 missing`.
 
 You can translate as much or as little as you like — a partial file is safe to
 ship. Anything you leave out falls back to English rather than rendering blank.
@@ -58,8 +58,8 @@ quietly rotting as the app grows.
 
 Completeness is measured per language, not key-for-key. Plural families are the
 exception: English defines `period.months_one` and `period.months_other`, but
-Japanese has a single plural category, so it owes only `_other` — 309 keys
-rather than 314. You are never asked for a form your language doesn't use.
+Japanese has a single plural category, so it owes only `_other` — 325 keys
+rather than 330. You are never asked for a form your language doesn't use.
 
 ### After adding or removing an English key
 
@@ -107,6 +107,31 @@ doesn't inflect.
 
 [cldr]: https://cldr.unicode.org/index/cldr-spec/plural-rules
 
+## Names that come in three widths
+
+Bureaus and application types each carry `.label`, `.short`, and `.compact`,
+because the interface asks for the same name in places with very different room:
+
+| Key | Where it renders | Budget |
+| --- | --- | --- |
+| `bureau.101210` | filter options, map hover card, table caption, screen-reader text | room to spare |
+| `bureau.101210.compact` | efficiency-chart label column, ring-chart legend, treemap tile | ~92px, truncates |
+| `bureau.101210.short` | nothing today; an IATA-style code — leave it Latin | 3 characters |
+| `appType.20` | filter options, estimator, tooltips | room to spare |
+| `appType.20.compact` | the Sankey's narrow layout, below 500px | ~90px, **no truncation** |
+| `appType.20.short` | stat-tile subtitle, treemap tooltip title | ~3 characters |
+
+Translate each width to fit its own budget rather than repeating the full name
+three times. Japanese is the worked example: `bureau.101210` is the full
+official 東京出入国在留管理局横浜支局, but `.compact` is just 横浜 — without that,
+every Tokyo-area office truncates to the same 「東京出入国在留」 and the efficiency
+chart stops being able to tell them apart. `appType.*.short` is the reverse
+case: English uses `EXT`, but a Latin abbreviation means nothing to a Japanese
+reader, so ja uses 更新 instead of copying the code.
+
+Nothing truncates the Sankey's `.compact` labels — an over-long one is drawn
+straight off the edge of the chart.
+
 ## What isn't translated, and why
 
 - **CSV exports** keep English column headers regardless of the interface
@@ -139,8 +164,16 @@ doesn't inflect.
 Four files under `components/bklit/charts/` are locally modified so chart axis
 ticks and tooltips follow the locale too: `chart-formatters.ts`,
 `chart-stat-flow.tsx`, `y-axis.tsx`, and `sankey/sankey-tooltip.tsx` (its row
-labels take `valueLabel` / `linkLabel` props rather than the upstream
-hardcoded "Sessions" and "Flow"). A re-vendor would overwrite them.
+labels take `valueLabel` / `linkLabel` props rather than the upstream hardcoded
+"Sessions" and "Flow"). A re-vendor would overwrite them; each carries a
+`LOCAL MODIFICATION` comment at the point of change.
+
+Two of those changes came out of translating Japanese rather than extracting
+English: `chart-stat-flow.tsx` also passes `locales` to `NumberFlow` (without
+it the animated value silently reverted to the browser's locale once the
+animation library loaded), and `y-axis.tsx` marks tick labels
+`whitespace-nowrap` (`100万` is wide enough to break across two lines in a 40px
+axis margin).
 
 Locale detection runs `?lang=` → `localStorage` → browser language → English.
 The browser step is gated on `LOCALE_SWITCHER_ENABLED`: while the switcher is
@@ -166,9 +199,28 @@ text children, and a `no-restricted-syntax` rule catches string literals in
 
 ## Current state
 
-The extraction is complete — 314 keys, covering the whole interface. Japanese
-is a stub of five strings, and **the language switcher is deliberately hidden**
-(`LOCALE_SWITCHER_ENABLED` in `config.ts`). Offering the switch before a
-language is actually translated is what got the original switcher pulled in
-v1.1.0. Turn the flag on once a locale has meaningful coverage; `?lang=ja`
-works regardless, for testing and for translators checking their work.
+330 keys, covering the whole interface, in two languages both marked
+`complete`: English and Japanese (325 keys — Japanese owes no `_one` members).
+**The language switcher is on** (`LOCALE_SWITCHER_ENABLED` in `config.ts`),
+which also turns on browser-language detection — the two are one flag precisely
+because auto-detecting a language is only safe while the visitor can switch
+back. A locale still at `in-progress` is safe to register and offer: it renders
+what it has and falls back to English for the rest.
+
+### Two checks coverage can't make
+
+Counting keys proves a locale isn't *missing* anything. It can't tell whether a
+key that is present was ever actually translated — a value copied over from
+English satisfies every count. So each locale also gets:
+
+- **Nothing left sitting at its English value.** An exact match with the
+  English source is an oversight rather than a decision.
+- **Every prose value written in the language's own script.** This catches what
+  the equality check misses: a line edited just enough to differ from English
+  while still being English. Registered per locale in `SCRIPT_OF`, so a
+  language whose script overlaps Latin simply opts out.
+
+Both skip values that are Latin on purpose — `nav.version`, `bureau.*.short`,
+`map.areaValue` — listed in `LATIN_BY_DESIGN`, and both apply to whatever a
+locale defines, so an `in-progress` file is held to the same standard on the
+part it has finished.

--- a/src/i18n/__tests__/catalogue.test.ts
+++ b/src/i18n/__tests__/catalogue.test.ts
@@ -7,10 +7,10 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { buildTemplate, EN_RELATIVE, TEMPLATE_RELATIVE } from '../../../scripts/localeTemplate';
-import type { LocaleMeta } from '../locales';
+import type { Locale, LocaleMeta } from '../locales';
 import { LOCALE_CODES, LOCALES } from '../locales';
 import { en } from '../locales/en';
-import type { PluralSuffix } from '../types';
+import type { DictionaryKey, PluralSuffix } from '../types';
 
 const PLURAL_SUFFIXES: PluralSuffix[] = ['zero', 'one', 'two', 'few', 'many', 'other'];
 const PLACEHOLDER = /\{(\w+)\}/g;
@@ -117,6 +117,50 @@ describe.each(translatedLocales)('%s catalogue', (code) => {
     const missing = [...bases].filter((base) => dictionary[`${base}_other`] === undefined);
     expect(missing).toEqual([]);
   });
+});
+
+// Coverage is only half of "translated". A key can be present and still be the
+// English string — copied across and never revisited — which the checks above
+// count as done. These two catch that, and they run per locale rather than for
+// `ja` specifically, so the next language inherits them.
+//
+// Values a complete locale is expected to leave in Latin script: airport-style
+// bureau codes, a version number, and a value carrying nothing but an SI unit
+// symbol. Anything else still reading as English is an oversight, not a choice.
+const LATIN_BY_DESIGN = new Set<string>([
+  'nav.version',
+  'map.areaValue',
+  ...Object.keys(en).filter((key) => key.startsWith('bureau.') && key.endsWith('.short')),
+]);
+
+/** Strips placeholders, digits, and punctuation — what's left is prose, if any. */
+const proseOf = (value: string): string => value.replace(PLACEHOLDER, '').replace(/[\s\d\p{P}\p{S}]/gu, '');
+
+/** Kana and kanji — the scripts a Japanese value has to be written in. */
+const SCRIPT_OF = { ja: /[぀-ヿ㐀-䶿一-鿿]/ } as const satisfies Partial<Record<Locale, RegExp>>;
+
+describe.each(translatedLocales)('%s catalogue, beyond coverage', (code) => {
+  const meta: LocaleMeta = LOCALES[code];
+  const dictionary = meta.dictionary as Record<string, string>;
+  // Only a key the locale actually claims: an in-progress file is expected to
+  // be missing keys, but the ones it does define should be real translations.
+  const translatable = Object.keys(dictionary).filter(
+    (key) => !LATIN_BY_DESIGN.has(key) && proseOf(dictionary[key]) !== ''
+  );
+
+  it('leaves nothing sitting at its English value by accident', () => {
+    const untouched = translatable.filter((key) => dictionary[key] === en[key as DictionaryKey]);
+    expect(untouched).toEqual([]);
+  });
+
+  const script = SCRIPT_OF[code as keyof typeof SCRIPT_OF];
+  if (script) {
+    it("writes every prose value in the language's own script", () => {
+      // Catches what the equality check above misses: a value edited just
+      // enough to differ from English while still being English.
+      expect(translatable.filter((key) => !script.test(dictionary[key]))).toEqual([]);
+    });
+  }
 });
 
 describe('locale registry', () => {

--- a/src/i18n/__tests__/plurals.test.tsx
+++ b/src/i18n/__tests__/plurals.test.tsx
@@ -47,12 +47,13 @@ describe('English plural selection', () => {
 });
 
 describe('Japanese plural selection', () => {
-  it('resolves through the single "other" category without falling back to a raw key', () => {
-    // ja.ts doesn't translate these yet, so every count must land on the
-    // English `_other` member — never on the bare family name.
+  it('resolves every count through the single "other" category', () => {
+    // Japanese has one CLDR category, so ja.ts defines only `_other` and both
+    // counts must land on it — never on the bare family name, and never on the
+    // English `_one` member that `Intl.PluralRules` can't select here.
     render('period.months', [1, 6], 'ja');
-    expect(screen.getByTestId('n1').textContent).toBe('1 months');
-    expect(screen.getByTestId('n6').textContent).toBe('6 months');
+    expect(screen.getByTestId('n1').textContent).toBe('1か月');
+    expect(screen.getByTestId('n6').textContent).toBe('6か月');
     expect(screen.queryByText('period.months')).toBeNull();
   });
 });

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -12,14 +12,19 @@ export const LOCALE_QUERY_PARAM = 'lang';
 /**
  * Whether the language switcher is offered in the UI.
  *
- * The extraction work is done — every string is addressable — but the
- * Japanese catalogue is still mostly English fallbacks, and shipping a visible
- * switcher before a locale is actually translated is what got the original
- * switcher pulled in v1.1.0. Flip this to `true` once a locale reaches
- * meaningful coverage; `?lang=` works regardless, for testing.
+ * On since the Japanese catalogue reached full coverage — the condition this
+ * flag was waiting for. It stayed off through v1.1.0 because shipping a
+ * visible switcher over a five-string stub is what got the original switcher
+ * pulled, and a partially translated dashboard reads as broken rather than
+ * multilingual.
  *
- * This flag also gates browser-language detection: auto-detecting Japanese
- * while the switcher is hidden would strand Japanese visitors in a
- * mostly-English dashboard with no way back to English.
+ * The flag also gates browser-language detection, and the two belong together:
+ * auto-detecting Japanese is only safe while the switcher is visible, because
+ * that is what gives a visitor a way back to English. Turning one on without
+ * the other is the failure mode this single flag exists to prevent.
+ *
+ * A locale that is still in progress should be kept out of the registry (or
+ * shipped behind `?lang=`, which works regardless) rather than handled by
+ * flipping this off again — that would take Japanese down with it.
  */
-export const LOCALE_SWITCHER_ENABLED = false;
+export const LOCALE_SWITCHER_ENABLED = true;

--- a/src/i18n/locales/_template.ts
+++ b/src/i18n/locales/_template.ts
@@ -311,40 +311,65 @@ export const template: Dictionary = {
   // 'footer.dataUpdated': 'data updated {date}',
 
   // ── Domain: immigration bureaus ──────────────────────────────────────────
-  // Keyed by e-Stat bureau code. `.short` is the terminal-style abbreviation
-  // shown on the stat tiles; leave it as the Latin code in most languages.
+  // Keyed by e-Stat bureau code, in three widths — the same shape the
+  // application types use.
+  //
+  // `.short` is the terminal-style abbreviation; leave it as the Latin code in
+  // most languages. `.compact` is the form the width-constrained surfaces use:
+  // the efficiency chart's 92px label column, the ring-chart legend, and the
+  // treemap's on-tile label. English says the same thing at both widths, but a
+  // language whose official office names run long — Japanese writes Yokohama as
+  // 東京出入国在留管理局横浜支局 — needs somewhere to put the short form, or every
+  // office in a region truncates to the same prefix and they stop being
+  // distinguishable.
   // 'bureau.all': 'Nationwide',
   // 'bureau.all.short': 'ALL',
+  // 'bureau.all.compact': 'Nationwide',
   // 'bureau.101010': 'Sapporo',
   // 'bureau.101010.short': 'CTS',
+  // 'bureau.101010.compact': 'Sapporo',
   // 'bureau.101090': 'Sendai',
   // 'bureau.101090.short': 'SDJ',
+  // 'bureau.101090.compact': 'Sendai',
   // 'bureau.101170': 'Shinagawa',
   // 'bureau.101170.short': 'SGW',
+  // 'bureau.101170.compact': 'Shinagawa',
   // 'bureau.101190': 'Narita Airport',
   // 'bureau.101190.short': 'NRT',
+  // 'bureau.101190.compact': 'Narita Airport',
   // 'bureau.101200': 'Haneda Airport',
   // 'bureau.101200.short': 'HND',
+  // 'bureau.101200.compact': 'Haneda Airport',
   // 'bureau.101210': 'Yokohama',
   // 'bureau.101210.short': 'YOK',
+  // 'bureau.101210.compact': 'Yokohama',
   // 'bureau.101350': 'Nagoya',
   // 'bureau.101350.short': 'NAG',
+  // 'bureau.101350.compact': 'Nagoya',
   // 'bureau.101370': 'Chubu Airport',
   // 'bureau.101370.short': 'NGO',
+  // 'bureau.101370.compact': 'Chubu Airport',
   // 'bureau.101460': 'Osaka',
   // 'bureau.101460.short': 'ITM',
+  // 'bureau.101460.compact': 'Osaka',
   // 'bureau.101480': 'Kansai Airport',
   // 'bureau.101480.short': 'KIX',
+  // 'bureau.101480.compact': 'Kansai Airport',
   // 'bureau.101490': 'Kobe',
   // 'bureau.101490.short': 'UKB',
+  // 'bureau.101490.compact': 'Kobe',
   // 'bureau.101580': 'Hiroshima',
   // 'bureau.101580.short': 'HIJ',
+  // 'bureau.101580.compact': 'Hiroshima',
   // 'bureau.101670': 'Takamatsu',
   // 'bureau.101670.short': 'TAK',
+  // 'bureau.101670.compact': 'Takamatsu',
   // 'bureau.101720': 'Fukuoka',
   // 'bureau.101720.short': 'FUK',
+  // 'bureau.101720.compact': 'Fukuoka',
   // 'bureau.101740': 'Naha',
   // 'bureau.101740.short': 'OKA',
+  // 'bureau.101740.compact': 'Naha',
 
   // ── Domain: application types ────────────────────────────────────────────
   // Keyed by e-Stat application type code. `.short` is the stat-tile

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -299,40 +299,65 @@ export const en = {
   'footer.dataUpdated': 'data updated {date}',
 
   // ── Domain: immigration bureaus ──────────────────────────────────────────
-  // Keyed by e-Stat bureau code. `.short` is the terminal-style abbreviation
-  // shown on the stat tiles; leave it as the Latin code in most languages.
+  // Keyed by e-Stat bureau code, in three widths — the same shape the
+  // application types use.
+  //
+  // `.short` is the terminal-style abbreviation; leave it as the Latin code in
+  // most languages. `.compact` is the form the width-constrained surfaces use:
+  // the efficiency chart's 92px label column, the ring-chart legend, and the
+  // treemap's on-tile label. English says the same thing at both widths, but a
+  // language whose official office names run long — Japanese writes Yokohama as
+  // 東京出入国在留管理局横浜支局 — needs somewhere to put the short form, or every
+  // office in a region truncates to the same prefix and they stop being
+  // distinguishable.
   'bureau.all': 'Nationwide',
   'bureau.all.short': 'ALL',
+  'bureau.all.compact': 'Nationwide',
   'bureau.101010': 'Sapporo',
   'bureau.101010.short': 'CTS',
+  'bureau.101010.compact': 'Sapporo',
   'bureau.101090': 'Sendai',
   'bureau.101090.short': 'SDJ',
+  'bureau.101090.compact': 'Sendai',
   'bureau.101170': 'Shinagawa',
   'bureau.101170.short': 'SGW',
+  'bureau.101170.compact': 'Shinagawa',
   'bureau.101190': 'Narita Airport',
   'bureau.101190.short': 'NRT',
+  'bureau.101190.compact': 'Narita Airport',
   'bureau.101200': 'Haneda Airport',
   'bureau.101200.short': 'HND',
+  'bureau.101200.compact': 'Haneda Airport',
   'bureau.101210': 'Yokohama',
   'bureau.101210.short': 'YOK',
+  'bureau.101210.compact': 'Yokohama',
   'bureau.101350': 'Nagoya',
   'bureau.101350.short': 'NAG',
+  'bureau.101350.compact': 'Nagoya',
   'bureau.101370': 'Chubu Airport',
   'bureau.101370.short': 'NGO',
+  'bureau.101370.compact': 'Chubu Airport',
   'bureau.101460': 'Osaka',
   'bureau.101460.short': 'ITM',
+  'bureau.101460.compact': 'Osaka',
   'bureau.101480': 'Kansai Airport',
   'bureau.101480.short': 'KIX',
+  'bureau.101480.compact': 'Kansai Airport',
   'bureau.101490': 'Kobe',
   'bureau.101490.short': 'UKB',
+  'bureau.101490.compact': 'Kobe',
   'bureau.101580': 'Hiroshima',
   'bureau.101580.short': 'HIJ',
+  'bureau.101580.compact': 'Hiroshima',
   'bureau.101670': 'Takamatsu',
   'bureau.101670.short': 'TAK',
+  'bureau.101670.compact': 'Takamatsu',
   'bureau.101720': 'Fukuoka',
   'bureau.101720.short': 'FUK',
+  'bureau.101720.compact': 'Fukuoka',
   'bureau.101740': 'Naha',
   'bureau.101740.short': 'OKA',
+  'bureau.101740.compact': 'Naha',
 
   // ── Domain: application types ────────────────────────────────────────────
   // Keyed by e-Stat application type code. `.short` is the stat-tile

--- a/src/i18n/locales/index.ts
+++ b/src/i18n/locales/index.ts
@@ -31,7 +31,7 @@ export interface LocaleMeta {
 
 export const LOCALES = {
   en: { code: 'en', nativeName: 'English', intlTag: 'en-US', status: 'complete', dictionary: en },
-  ja: { code: 'ja', nativeName: '日本語', intlTag: 'ja-JP', status: 'in-progress', dictionary: ja },
+  ja: { code: 'ja', nativeName: '日本語', intlTag: 'ja-JP', status: 'complete', dictionary: ja },
 } as const satisfies Record<string, LocaleMeta>;
 
 export type Locale = keyof typeof LOCALES;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1,10 +1,23 @@
 // src/i18n/locales/ja.ts
-// Japanese overrides. Partial while translation is in progress — any key left
-// out falls back to the English string, so this file can grow one section at a
-// time without ever leaving a blank in the UI.
+// Japanese catalogue — complete coverage of the English source.
 //
-// Japanese has a single CLDR plural category, so plural families only ever
-// need their `_other` member here.
+// Conventions, kept deliberately consistent so the file reads as one voice:
+//
+// - 体言止め for anything that labels a control: buttons, tabs, filter labels,
+//   column headers, stat-tile titles. です・ます for anything that speaks to the
+//   reader: explanatory prose, warnings, empty and error states.
+// - Official 出入国在留管理庁 terminology for the domain nouns. Application types
+//   use the agency's own procedure names (在留資格取得許可申請 and so on), and
+//   bureaus their full office names including 支局 status.
+// - Full-width punctuation (：（）、。), ranges joined with 〜, and no space
+//   between a number and its unit — 12,345件, 6か月, 1,234km².
+// - Japanese has a single CLDR plural category, so plural families define only
+//   their `_other` member. `Intl.PluralRules('ja-JP')` never selects anything
+//   else, and translate.ts falls back to `_other` regardless.
+//
+// A few values are intentionally identical to English: `nav.version` is a
+// version number, and `bureau.*.short` are IATA-style codes that stay Latin in
+// every language (see the note in en.ts).
 import type { Dictionary } from '../types';
 
 export const ja: Dictionary = {
@@ -12,10 +25,410 @@ export const ja: Dictionary = {
   'app.title': '日本 在留審査統計',
   'app.subtitle': '出入国在留管理庁の審査データ（e-Stat の公表に合わせて更新）',
   'app.skipToContent': '本文へスキップ',
+  'app.loadingData': '在留統計を集計しています…',
+  'app.loadingDashboard': 'ダッシュボードを読み込んでいます…',
+  'app.retry': '再試行',
+
+  // ── Document metadata ────────────────────────────────────────────────────
+  // Not yet reachable: the static export prerenders one English document (see
+  // src/i18n/README.md). Translated so it is ready when per-locale routes are.
+  'meta.title': '日本 在留審査統計ダッシュボード',
+  'meta.description':
+    '在留審査の処理期間、地方出入国在留管理局ごとの処理状況、そして自分の申請に合わせた待ち行列モデルによる完了時期の推定。出入国在留管理庁の公式統計にもとづき、e-Stat の新規データ公表（おおむね月次）に合わせて更新しています。',
+  'meta.keywords': '在留審査 処理期間, 出入国在留管理局 統計, 在留申請 進捗, 出入国在留管理庁, e-Stat',
+
+  // ── Header and settings drawer ───────────────────────────────────────────
+  'nav.version': 'v{version}',
+  'nav.language': '言語',
+  'nav.switchToLightTheme': 'ライトテーマに切り替え',
+  'nav.switchToDarkTheme': 'ダークテーマに切り替え',
+  'nav.openSettings': '設定メニューを開く',
+  'nav.settings': '設定',
+  'nav.theme': 'テーマ',
+  'nav.themeLight': 'ライト',
+  'nav.themeDark': 'ダーク',
+  'nav.about': 'このサイトについて',
+  'nav.changelog': '更新履歴',
+
+  // ── Dashboard chrome ─────────────────────────────────────────────────────
+  'dashboard.dataCoverage': '対象期間：{range}',
+  'dashboard.coverageRange': '{from}〜{to}',
+  'dashboard.comparisonSuffix': '（比較）',
+  'dashboard.expandEstimator': '審査期間の目安を開く',
+  'dashboard.estimatorRail': '審査目安',
+
+  // ── Filters ──────────────────────────────────────────────────────────────
+  'filters.bureau': '出入国在留管理局',
+  'filters.appType': '申請種別',
+  'filters.compare': '比較対象',
+  'filters.compareNone': 'なし',
+  'filters.excludeAirports': '空港支局を除く',
+  'filters.includeAirports': '空港支局を含む',
+  'filters.reset': 'フィルターをリセット',
+  'filters.selectPlaceholder': '選択',
+
+  // ── Time range selector ──────────────────────────────────────────────────
+  'period.label': '表示期間',
+  'period.latest': '最新月',
+  'period.all': '全期間',
+  'period.months_other': '{count}か月',
+
+  // ── Stat tiles ───────────────────────────────────────────────────────────
+  'stats.totalApplications': '申請総数',
+  'stats.totalApplications.short': '総数',
+  'stats.pending': '未処理',
+  'stats.granted': '許可',
+  'stats.denied': '不許可',
+  'stats.approvalRate': '許可率',
+  'stats.approvalRate.short': '許可率',
+  'stats.scopeWithType': '{bureau}（{type}）',
+  // {delta} arrives already signed and formatted, so it follows 前月比 directly.
+  'stats.momDelta': '前月比{delta}',
+
+  // ── Shared vocabulary ────────────────────────────────────────────────────
+  // e-Stat's own column vocabulary for the source table (在留資格の取得等の
+  // 受理及び処理人員), kept consistent across the table, legends, and hover cards.
+  'metric.carriedOver': '繰越',
+  'metric.pending': '未処理（繰越）',
+  'metric.received': '受理',
+  'metric.processed': '処理',
+  'metric.granted': '許可',
+  'metric.denied': '不許可',
+  'metric.other': 'その他',
+  'metric.completion': '処理率',
+  'metric.applications': '申請数',
+  'metric.population': '人口',
+  'metric.area': '面積',
+  'metric.density': '人口密度',
+  'common.noDataForFilters': 'この条件に該当するデータはありません。',
+
+  // ── Data table ───────────────────────────────────────────────────────────
+  'table.view': 'データ表を表示',
+  'table.hide': 'データ表を非表示',
+  'table.downloadCsv': 'CSV をダウンロード',
+  'table.caption': '{bureau}の月別申請統計',
+  'table.month': '月',
 
   // ── Estimator ────────────────────────────────────────────────────────────
   'estimator.title': '審査期間の目安',
+  'estimator.description': '直近6か月の処理実績にもとづく待ち行列モデルによる推定です。',
+  'estimator.selectBureau': '管理局を選択',
+  'estimator.selectType': '申請種別を選択',
+  'estimator.applicationDate': '申請日',
+  'estimator.empty':
+    '出入国在留管理局、申請種別、申請日を選択すると、審査が完了する時期の目安が表示されます。',
+  'estimator.estimatedCompletion': '完了予定時期',
+  'estimator.queuePosition': '待ち順位',
+  'estimator.aheadOfYou': '前に約{count}件',
+  'estimator.howCalculated': '算出方法について',
+  'estimator.showMath': '計算式を表示',
+  'estimator.hideMath': '計算式を非表示',
+  'estimator.reset': '目安をリセット',
+  'estimator.resetAria': '審査期間の目安をリセット',
+  'estimator.collapse': '目安を折りたたむ',
+  'estimator.collapseAria': '審査期間の目安を折りたたむ',
+  'estimator.close': '目安を閉じる',
+  'estimator.closeAria': '審査期間の目安を閉じる',
+  'estimator.copyPermalink': 'この推定結果のリンクをコピー',
+  'estimator.copied': 'コピーしました',
+  // Joined with " · " at the call site, so each half stands on its own.
+  'estimator.uncertaintyDays_other': '±{count}日',
+  'estimator.uncertaintyWeeks_other': '±{count}週間',
+  'estimator.basedOnMonths_other': '直近{count}か月の処理実績にもとづく',
+  // Warnings.
+  'estimator.limitedDataTitle': 'データが限られています：',
+  'estimator.limitedDataBody_other':
+    '申請日がデータの対象期間を超えています。この推定は{count}か月分の実績から処理速度を推計したものであり、精度が低くなる場合があります。',
+  'estimator.pastDueTitle': '完了予定を過ぎている可能性があります：',
+  'estimator.pastDueBody':
+    '想定される処理速度からみて、この申請は完了予定時期を過ぎている可能性があります。追加資料の求めや処分の通知がまだ届いていない場合は、申請先の官署にお問い合わせください。',
+  // {emphasis} is the word 推定値, rendered bold and underlined.
+  'estimator.disclaimer':
+    '※これは現在の処理速度、想定される待ち順位、未処理件数にもとづく{emphasis}です。実際の審査期間は異なる場合があります。',
+  'estimator.disclaimerEmphasis': '推定値',
+
+  // ── Estimator: the "Show the math" breakdown ─────────────────────────────
+  'estimator.formula.step1': '申請時点の待ち行列',
+  'estimator.formula.step2': '待ち順位と1日あたりの処理数',
+  'estimator.formula.step3': '残り日数',
+  'estimator.formula.explainAria': '{title}の計算式に含まれる変数の説明',
+  'estimator.formula.var.dRem.title': '残り日数',
+  'estimator.formula.var.dRem.description': '審査が完了するまでの推定日数。',
+  'estimator.formula.var.qPos.title': '待ち順位',
+  'estimator.formula.var.qPos.description': '審査待ち行列における推定順位。',
+  'estimator.formula.var.rDaily.title': '1日あたりの処理数',
+  'estimator.formula.var.rDaily.description': '1日に処理される申請の平均件数。',
+  'estimator.formula.var.cProc.title': '処理済（実績）',
+  'estimator.formula.var.cProc.description': '申請以降に処理された申請の確定件数。',
+  'estimator.formula.var.eProc.title': '処理済（推定）',
+  'estimator.formula.var.eProc.description': '直近のデータ以降に処理されたと推定される申請件数。',
+  'estimator.formula.var.sigmaP.title': '処理件数の合計',
+  'estimator.formula.var.sigmaP.description': '平均の算出に用いた処理件数の合計。',
+  'estimator.formula.var.sigmaD.title': '日数の合計',
+  'estimator.formula.var.sigmaD.description': '平均の算出に用いた日数の合計。',
+  'estimator.formula.var.qApp.title': '申請時の待ち行列',
+  'estimator.formula.var.qApp.description': '申請時点における推定待ち順位。',
+  'estimator.formula.var.cPrev.title': '前月からの繰越',
+  'estimator.formula.var.cPrev.description': '前月から繰り越された申請件数。',
+  'estimator.formula.var.nApp.title': '新規申請',
+  'estimator.formula.var.nApp.description': '申請日までに受理されたと推定される申請件数。',
+  'estimator.formula.var.pApp.title': '処理済申請',
+  'estimator.formula.var.pApp.description': '申請日までに処理されたと推定される申請件数。',
+
+  // ── Charts: registry ─────────────────────────────────────────────────────
+  'charts.intake.label': '受理と処理',
+  'charts.intake.description': '月ごとの繰越・受理件数と、各官署が処理した件数の推移です。',
+  'charts.intake.aria': '月別の未処理件数と受理件数を積み上げた棒グラフ。処理件数を折れ線で重ねて表示',
+  'charts.types.label': '申請種別',
+  'charts.types.description':
+    '月ごとの新規受理件数を申請種別ごとに表示します。凡例をクリックすると系列の表示を切り替えられます。',
+  'charts.types.aria': '申請種別ごとの月別新規受理件数の折れ線グラフ',
+  'charts.outcomes.label': '処理結果',
+  'charts.outcomes.description': '申請がどの結果に至ったか。申請種別ごとの許可・不許可・その他への流れです。',
+  'charts.outcomes.aria': '申請種別から処理結果への流れを示すサンキー図',
+  'charts.share.label': '官署別割合',
+  'charts.share.description': 'どの官署に申請が集まっているか。受理件数全体に占める各官署の割合です。',
+  'charts.share.aria': '各官署の受理件数の割合を示すドーナツグラフ',
+  'charts.mix.label': '種別構成',
+  'charts.mix.description': '申請種別と官署による全申請の構成です。カテゴリをクリックすると内訳を拡大できます。',
+  'charts.efficiency.label': '処理効率',
+  'charts.efficiency.description':
+    '処理率の高い順に並べた官署の一覧です。軸の太さは受理件数を、基準線は全国の処理率を表します。',
+  'charts.efficiency.aria': '処理率順に並べた官署のランキング。軸の太さは受理件数を表す',
+  'charts.map.label': '地域別マップ',
+  'charts.map.description': '各官署の管轄区域と人口密度、および管理局・空港支局の所在地です。',
+  // Alternate views, kept swap-ready but not currently registered.
+  'charts.mixSunburst.aria': '申請種別と官署による申請のサンバースト図。ドリルダウン操作が可能',
+  'charts.efficiencyQuadrant.aria':
+    '官署ごとの処理率と受理件数の四象限グラフ。バブルの大きさは処理件数を表す',
+
+  // ── Charts: shared ───────────────────────────────────────────────────────
+  'chart.legendShow': '{series}を表示',
+  'chart.legendHide': '{series}を非表示',
+  'chart.allSeriesHidden': 'すべての系列が非表示です。凡例をクリックすると表示されます。',
+
+  // ── Chart: Application Types ─────────────────────────────────────────────
+  // Series names for the wrapping legend, so these can be fuller than the
+  // Sankey's `appType.*.compact` forms.
+  'chart.types.series.acquisition': '在留資格取得',
+  'chart.types.series.extension': '在留期間更新',
+  'chart.types.series.change': '在留資格変更',
+  'chart.types.series.activity': '資格外活動',
+  'chart.types.series.reentry': '再入国',
+  'chart.types.series.permanent': '永住',
+
+  // ── Chart: Outcomes ──────────────────────────────────────────────────────
+  'chart.outcomes.otherWithdrawn': 'その他・取下げ',
+  'chart.outcomes.valueUnit': '件',
+  // Row labels in the Sankey tooltip: the node row counts applications, the
+  // link row measures what flows along that connection.
+  'chart.outcomes.tooltipValueLabel': '申請数',
+  'chart.outcomes.tooltipFlowLabel': '流量',
+  'chart.outcomes.approvalRate': '許可率',
+  'chart.outcomes.ofProcessed': '処理済{count}件に対する割合',
+  'chart.outcomes.empty': 'この期間に処理された申請はありません。',
+
+  // ── Chart: Bureau Share ──────────────────────────────────────────────────
+  'chart.share.otherSlice': 'その他（{count}）',
+
+  // ── Chart: Category Mix ──────────────────────────────────────────────────
+  'chart.mix.root': '全申請',
+  'chart.mix.breadcrumbAria': 'ツリーマップの階層パス',
+  'chart.mix.zoomInHint': 'カテゴリをクリックすると拡大します',
+  'chart.mix.zoomOutHint': '背景をクリック（または Esc キー）で戻ります',
+  'chart.mix.others': 'その他',
+  'chart.mix.categoryAria': '{category}：{count}件。拡大します。',
+  'chart.mix.tooltipValue': '{count}件・{scope}の{percent}',
+  'chart.mix.scopeAll': '全申請',
+  'chart.mix.sunburstHint': '{trail} — {count}件（全体の{percent}）',
+
+  // ── Chart: Processing Efficiency ─────────────────────────────────────────
+  'chart.efficiency.branchOffice': '支局',
+  'chart.efficiency.receivedCount': '受理{count}件',
+  'chart.efficiency.nationwide': '全国 {rate}',
+  'chart.efficiency.pointAria': '{bureau}：処理率{rate}パーセント、受理{count}件',
+  'chart.efficiency.xAxis': '受理件数',
+  'chart.efficiency.fullCompletion': '受理件数の100%を処理',
+  'chart.efficiency.quadrantKeepingPace': '高負荷・処理は追随',
+  'chart.efficiency.quadrantFallingBehind': '高負荷・処理が遅延',
+
+  // ── Chart: Regional Map ──────────────────────────────────────────────────
+  // The bureau labels already end in 出入国在留管理局 / 支局, so these carry no
+  // suffix of their own — appending one would repeat the office type.
+  'map.bureauMarkerAria': '{bureau}',
+  'map.airportMarkerAria': '{bureau}',
+  'map.bureauSuffix': '{bureau}',
+  'map.airportSuffix': '{bureau}',
+  'map.servicePopulation': '管轄人口',
+  'map.serviceArea': '管轄面積',
+  'map.serviceBureau': '管轄官署',
+  'map.portOfEntry': '出入国港の官署',
+  'map.legendNote': '色＝管轄官署・濃さ＝人口密度',
+  'map.bureau': '管理局',
+  'map.airportOffice': '空港支局',
+  'map.zoomIn': '拡大',
+  'map.zoomOut': '縮小',
+  'map.resetView': '表示をリセット',
+  'map.loadError': '地図データを読み込めませんでした。ページを再読み込みしてください。',
+  'map.loading': '地図データを読み込んでいます…',
+  'map.areaValue': '{value}km²',
+  'map.densityValue': '{value}人/km²',
+
+  // ── Changelog ────────────────────────────────────────────────────────────
+  'changelog.title': '更新履歴',
+  'changelog.loading': '読み込み中…',
+
+  // ── Errors ───────────────────────────────────────────────────────────────
+  'errors.dataTitle': 'データの読み込みエラー',
+  'errors.noData': 'データがありません',
+  'errors.unknown': '不明なエラーが発生しました',
+  'errors.fetchFailed': 'データを取得できませんでした',
+  'errors.renderTitle': '問題が発生しました',
+  'errors.renderBody': '画面の表示中にエラーが発生しました。',
+  'errors.reload': 'ページを再読み込み',
+  'errors.changelogUnavailable': '更新履歴を読み込めませんでした。',
+
+  // ── Screen-reader only ───────────────────────────────────────────────────
+  'a11y.showingChart': '{bureau}の{chart}を表示中',
+  'a11y.showingChartWithType': '{bureau}・{type}の{chart}を表示中',
 
   // ── Footer ───────────────────────────────────────────────────────────────
   'footer.attribution': '統計データ提供：出入国在留管理庁',
+  'footer.dataAcquisition': 'データ取得元：{source}',
+  'footer.fixtureNotice': '生成されたサンプルデータを表示中',
+  'footer.builtBy': '制作：{author}',
+  'footer.dataUpdated': 'データ更新日 {date}',
+
+  // ── Domain: immigration bureaus ──────────────────────────────────────────
+  // Full official office names, including 支局 status: the eight regional
+  // 地方出入国在留管理局 plus seven branch offices. `.short` stays Latin (IATA
+  // codes). `.compact` is the place name alone, for the surfaces that measure
+  // in pixels — without it every 東京-family office truncates to 「東京出入国在留」.
+  'bureau.all': '全国',
+  'bureau.all.short': 'ALL',
+  'bureau.all.compact': '全国',
+  'bureau.101010': '札幌出入国在留管理局',
+  'bureau.101010.short': 'CTS',
+  'bureau.101010.compact': '札幌',
+  'bureau.101090': '仙台出入国在留管理局',
+  'bureau.101090.short': 'SDJ',
+  'bureau.101090.compact': '仙台',
+  'bureau.101170': '東京出入国在留管理局',
+  'bureau.101170.short': 'SGW',
+  'bureau.101170.compact': '東京',
+  'bureau.101190': '東京出入国在留管理局成田空港支局',
+  'bureau.101190.short': 'NRT',
+  'bureau.101190.compact': '成田空港',
+  'bureau.101200': '東京出入国在留管理局羽田空港支局',
+  'bureau.101200.short': 'HND',
+  'bureau.101200.compact': '羽田空港',
+  'bureau.101210': '東京出入国在留管理局横浜支局',
+  'bureau.101210.short': 'YOK',
+  'bureau.101210.compact': '横浜',
+  'bureau.101350': '名古屋出入国在留管理局',
+  'bureau.101350.short': 'NAG',
+  'bureau.101350.compact': '名古屋',
+  'bureau.101370': '名古屋出入国在留管理局中部空港支局',
+  'bureau.101370.short': 'NGO',
+  'bureau.101370.compact': '中部空港',
+  'bureau.101460': '大阪出入国在留管理局',
+  'bureau.101460.short': 'ITM',
+  'bureau.101460.compact': '大阪',
+  'bureau.101480': '大阪出入国在留管理局関西空港支局',
+  'bureau.101480.short': 'KIX',
+  'bureau.101480.compact': '関西空港',
+  'bureau.101490': '大阪出入国在留管理局神戸支局',
+  'bureau.101490.short': 'UKB',
+  'bureau.101490.compact': '神戸',
+  'bureau.101580': '広島出入国在留管理局',
+  'bureau.101580.short': 'HIJ',
+  'bureau.101580.compact': '広島',
+  'bureau.101670': '高松出入国在留管理局',
+  'bureau.101670.short': 'TAK',
+  'bureau.101670.compact': '高松',
+  'bureau.101720': '福岡出入国在留管理局',
+  'bureau.101720.short': 'FUK',
+  'bureau.101720.compact': '福岡',
+  'bureau.101740': '福岡出入国在留管理局那覇支局',
+  'bureau.101740.short': 'OKA',
+  'bureau.101740.compact': '那覇',
+
+  // ── Domain: application types ────────────────────────────────────────────
+  // The agency's own procedure names. `.short` uses the two-character forms a
+  // Japanese reader can scan on a stat tile, where the Latin codes English uses
+  // would carry no meaning; `.compact` is the narrow Sankey's one-word form.
+  'appType.all': 'すべての種別',
+  'appType.all.short': '全種別',
+  'appType.all.compact': 'すべて',
+  'appType.10': '在留資格取得許可申請',
+  'appType.10.short': '取得',
+  'appType.10.compact': '資格取得',
+  'appType.20': '在留期間更新許可申請',
+  'appType.20.short': '更新',
+  'appType.20.compact': '期間更新',
+  'appType.30': '在留資格変更許可申請',
+  'appType.30.short': '変更',
+  'appType.30.compact': '資格変更',
+  'appType.40': '資格外活動許可申請',
+  'appType.40.short': '資格外',
+  'appType.40.compact': '資格外活動',
+  'appType.50': '再入国許可申請',
+  'appType.50.short': '再入国',
+  'appType.50.compact': '再入国',
+  'appType.60': '永住許可申請',
+  'appType.60.short': '永住',
+  'appType.60.compact': '永住',
+
+  // ── Domain: prefectures ──────────────────────────────────────────────────
+  // Keyed by JIS prefecture code, carrying the 都・道・府・県 suffix. These match
+  // the `name_ja` property in public/static/japan.topo.json exactly, which is
+  // what stops the choropleth tooltip printing every name twice — it shows the
+  // Japanese name as a secondary only when it differs from the catalogue's.
+  'prefecture.1': '北海道',
+  'prefecture.2': '青森県',
+  'prefecture.3': '岩手県',
+  'prefecture.4': '宮城県',
+  'prefecture.5': '秋田県',
+  'prefecture.6': '山形県',
+  'prefecture.7': '福島県',
+  'prefecture.8': '茨城県',
+  'prefecture.9': '栃木県',
+  'prefecture.10': '群馬県',
+  'prefecture.11': '埼玉県',
+  'prefecture.12': '千葉県',
+  'prefecture.13': '東京都',
+  'prefecture.14': '神奈川県',
+  'prefecture.15': '新潟県',
+  'prefecture.16': '富山県',
+  'prefecture.17': '石川県',
+  'prefecture.18': '福井県',
+  'prefecture.19': '山梨県',
+  'prefecture.20': '長野県',
+  'prefecture.21': '岐阜県',
+  'prefecture.22': '静岡県',
+  'prefecture.23': '愛知県',
+  'prefecture.24': '三重県',
+  'prefecture.25': '滋賀県',
+  'prefecture.26': '京都府',
+  'prefecture.27': '大阪府',
+  'prefecture.28': '兵庫県',
+  'prefecture.29': '奈良県',
+  'prefecture.30': '和歌山県',
+  'prefecture.31': '鳥取県',
+  'prefecture.32': '島根県',
+  'prefecture.33': '岡山県',
+  'prefecture.34': '広島県',
+  'prefecture.35': '山口県',
+  'prefecture.36': '徳島県',
+  'prefecture.37': '香川県',
+  'prefecture.38': '愛媛県',
+  'prefecture.39': '高知県',
+  'prefecture.40': '福岡県',
+  'prefecture.41': '佐賀県',
+  'prefecture.42': '長崎県',
+  'prefecture.43': '熊本県',
+  'prefecture.44': '大分県',
+  'prefecture.45': '宮崎県',
+  'prefecture.46': '鹿児島県',
+  'prefecture.47': '沖縄県',
 };

--- a/src/i18n/useDomainLabels.ts
+++ b/src/i18n/useDomainLabels.ts
@@ -25,6 +25,8 @@ import type { DictionaryKey } from './types';
 export interface LabeledBureau extends BureauOption {
   label: string;
   short: string;
+  /** The form the width-constrained surfaces use — see `bureau.*.compact`. */
+  compact: string;
 }
 
 export interface LabeledApplicationType extends ApplicationOption {
@@ -67,6 +69,7 @@ export const useBureauOptions = (): LabeledBureau[] => {
         ...option,
         label: t(`bureau.${option.value}` as DictionaryKey),
         short: t(`bureau.${option.value}.short` as DictionaryKey),
+        compact: t(`bureau.${option.value}.compact` as DictionaryKey),
       })),
     [t]
   );
@@ -86,6 +89,19 @@ export const useBureauLabel = (): ((code: string) => string) => {
   const bureaus = useBureauOptions();
   return useMemo(() => {
     const byCode = new Map(bureaus.map((option) => [option.value, option.label]));
+    return (code: string) => byCode.get(code) ?? code;
+  }, [bureaus]);
+};
+
+/**
+ * `(code) => short name`, for the surfaces that measure in pixels rather than
+ * words: the efficiency chart's label column, the ring-chart legend, and the
+ * treemap's on-tile label. Same fallback as `useBureauLabel`.
+ */
+export const useBureauCompact = (): ((code: string) => string) => {
+  const bureaus = useBureauOptions();
+  return useMemo(() => {
+    const byCode = new Map(bureaus.map((option) => [option.value, option.compact]));
     return (code: string) => byCode.get(code) ?? code;
   }, [bureaus]);
 };

--- a/src/index.css
+++ b/src/index.css
@@ -171,6 +171,14 @@
   --font-sans: 'Inter Variable', 'Noto Sans JP Variable', system-ui, -apple-system, 'Segoe UI', 'Hiragino Sans',
     'Yu Gothic UI', sans-serif;
 
+  /* Tailwind's default mono stack is Latin-only, so the treemap's `font-mono`
+     tooltip — which carries a translated sentence, not just figures — dropped
+     Japanese onto whatever the browser happened to pick. The JP faces are
+     appended rather than substituted: digits still get the monospace figures
+     the tooltip is aligned around, and only the kana/kanji fall through. */
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Noto Sans JP Variable', 'Hiragino Sans',
+    'Yu Gothic UI', monospace;
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## Summary

The localization scaffolding on `feat/localization-support` landed without a second language: `ja.ts` was five strings, so `?lang=ja` rendered a mostly-English dashboard and `LOCALE_SWITCHER_ENABLED` stayed off. This branch fills the catalogue in, wires up the label tier the dense charts need to stay readable, and turns the flag on.

Base is `feat/localization-support`, not `main`. #55 has since squash-merged into `main` as `1e3718e` (v1.2.0); the base branch is now `main` plus one commit, so this stays a one-commit diff either way.

## The catalogue

All 330 keys (325 for Japanese, which owes no `_one` members), 体言止め for controls (`申請総数`, `フィルターをリセット`) and です・ます for prose, warnings, and empty states. Terminology comes from sources rather than from feel:

- **Application types** use the agency's own procedure names — `在留資格取得許可申請`, `在留期間更新許可申請`, `在留資格変更許可申請`, `資格外活動許可申請`, `再入国許可申請`, `永住許可申請`.
- **Bureaus** carry their full official office names including branch status: the eight 地方出入国在留管理局 plus seven 支局. This matches the parent/child structure already encoded in `bureauOptions.ts`.
- **Statistical vocabulary** follows the e-Stat source table (出入国管理統計 / 在留資格の取得等の受理及び処理人員) — 受理・処理・許可・不許可・その他・繰越・未処理.
- **Prefectures** are taken from the repo's own `public/static/japan.topo.json` `name_ja`. Matching it exactly is not just convenient: `GeographicDistributionChart.tsx` prints `name_ja` as a secondary only when it differs from the catalogue name, so this is what stops the Japanese tooltip printing every prefecture twice.

Punctuation follows Japanese convention throughout — full-width `：（）、。`, ranges as `{from}〜{to}`, and no space between a number and its unit (`12,345件`, `6か月`, `1,234km²`). Plural families define only `_other`, since `Intl.PluralRules('ja-JP')` never selects anything else.

`ja` moves to `status: 'complete'` in the registry, which turns the base's coverage gate from a report into a build failure the moment English gains a key Japanese lacks.

## Bureaus gained a third width

`bureau.*.short` (the IATA-style `CTS`/`NRT` codes) turned out to have **no UI consumer at all** — only tests read it. So the full official names would have landed unmitigated in the Processing Efficiency chart's 92px `truncate` label column, where all four Tokyo-family offices clip to the identical 「東京出入国在留」 and the three Osaka ones to 「大阪出入国在」. That chart *ranks bureaus against each other*, so this was a correctness failure rather than a cosmetic one.

`bureau.*.compact` mirrors the `appType.*.label/.short/.compact` pattern already in the catalogue. The full name keeps the surfaces with room (filter options, map hover card, table caption, screen-reader announcements); `.compact` takes the three that measure in pixels — the efficiency label column, the ring-chart legend, and the treemap tile. English `.compact` repeats its `.label`, so **English rendering is byte-identical**.

`appType.*.short` went the other way: English uses `EXT`/`CHG`, but a Latin abbreviation carries no meaning for a Japanese reader, so ja uses `更新`/`変更` in the same 3-character budget.

## Three defects that only appear in Japanese

Found by rendering it, not by reading it:

- **`CategoryMixTreemap.tsx`** renders translated prose inside a `font-mono` node, but no `--font-mono` was defined — Tailwind's Latin-only default applied and the browser picked its own fallback. Added a `--font-mono` with the JP faces appended, so digits keep monospace figures and only kana/kanji fall through.
- **`chart-stat-flow.tsx`** passed no `locales` prop to the `NumberFlow` element, so an animated value reverted to the browser's locale the moment the animation library loaded, while the static fallback beside it stayed correct. `pie-center` and `ring-center` route through the same component and are covered by the one fix.
- **`y-axis.tsx`** — a `100万` tick is just wide enough to wrap inside the 40px axis margin, dropping `万` onto its own line. Marked `whitespace-nowrap`; a numeric axis label should never wrap in any language.

All three are in the vendored Bklit tree or its theme, and each carries a `LOCAL MODIFICATION` comment for the next re-vendor.

## The switcher

`LOCALE_SWITCHER_ENABLED` is now `true`. It also gates browser-language detection, and the two are deliberately one flag: auto-detecting a language is only safe while the visitor has a visible way back to English. A locale still at `in-progress` is safe to register and offer alongside it — it renders what it has and falls back to English for the rest — so a future partial translation needs no change to this flag.

## Tests

Three assertions pinned the stub state and now test the translation instead. Because both gating states of the switcher matter regardless of which way the flag ships, each is now mocked explicitly rather than reading the default — `LanguageSwitcherGate.test.tsx` is the off half, `LanguageSwitcher.test.tsx` the on half.

Coverage is only half of "translated": a key can be present and still be the English string, copied across and never revisited, which every count treats as done. `catalogue.test.ts` gains two checks for that, running per locale rather than for `ja` specifically:

- **Nothing left sitting at its English value** — an exact match with the English source is an oversight, not a decision.
- **Every prose value written in the language's own script** — catches what the equality check misses, a line edited just enough to differ from English while still being English. Registered per locale in `SCRIPT_OF`, so a Latin-script language opts out.

Both skip the values that are Latin on purpose (`nav.version`, `bureau.*.short`, `map.areaValue`, listed in `LATIN_BY_DESIGN`), and both apply to whatever a locale defines, so an `in-progress` file is held to the same standard on the part it has finished.

Both were negative-tested by deliberately breaking `ja.ts`, alongside the base's coverage gate: each caught its intended defect and nothing else.

## Test plan

Run as CI now runs it, through the split `verify.yaml`:

- [x] lockfile shaken (`node node_modules/lockfile-shaker/lib/bin.js` leaves `package-lock.json` clean)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 96 passing
- [x] `npm run build` — static export
- [x] `npm run i18n:template` — regenerates to no diff, so the committed template matches `en.ts`
- [x] Playwright captures of both languages at 1440 / 1024 / 375px across all seven charts, plus the data table, the filled-in estimator, the treemap tooltip, the map marker hover card, and the choropleth tooltip. English re-checked at the same viewports, since the `.compact` tier and the y-axis fix touch shared code.
- [x] Re-verified after each rebase: the Processing Efficiency chart (whose axis the base reworked in the same region as the `.compact` label swap) and the Sankey tooltip's translated row labels.

## Known limitations, not addressed here

- The served HTML always carries `lang="en"`; it is corrected client-side after hydration. A real fix needs per-locale routes, which is a much larger change than this branch. `meta.*` and `manifest.webmanifest` stay English for the same reason — the `meta.*` values are translated anyway, so they are ready when routes arrive.
- CSV exports keep English column headers by design.
- `uppercase` / `tracking-wider` remain on several catalogue-fed labels — harmless, but not idiomatic Japanese typography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaMXEDfYcurCmppTX6sxHf

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaMXEDfYcurCmppTX6sxHf)_