### PR TITLE
Bump version to 1.1.1 and add changelog entry for efficiency axis fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Fixed
 
+- **v1.1.1**: The Processing Efficiency chart clamped its axis at 100%, so bureaus clearing backlog above 100% all pinned to the right edge at the same position — the axis now scales past 100% to fit the highest rate. ([#57](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/57))
 - **v1.1.0**: Layout and estimator fixes —
   - The formula breakdown listed its steps in reverse — the final calculation was shown first, ahead of the values it depends on
   - The filter bar's controls wrapped and crowded each other at the layout widths where the estimator sidebar narrows the panel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp_immigration_dashboard",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "overrides": {


### PR DESCRIPTION
Follow-up to #57, which shipped without a version bump or changelog entry.

- Bumps `package.json` / `package-lock.json` from 1.1.0 to **1.1.1** (the version shown in the dashboard header)
- Adds a v1.1.1 entry to `CHANGELOG.md` under 2026-07 → Fixed, describing the Processing Efficiency axis-clamping fix and linking #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151BspwUZCBcGdygHdVS3Lb

---
_Generated by [Claude Code](https://claude.ai/code/session_0151BspwUZCBcGdygHdVS3Lb)_