### PR TITLE
Fix Outcomes Sankey chart tooltip label from "Sessions" to "Applications"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Fixed
 
+- **v1.1.2**: The Outcomes Sankey chart's tooltip labelled application counts "Sessions" — a leftover from the chart library's web-analytics defaults — instead of "Applications".
 - **v1.1.1**: The Processing Efficiency chart clamped its axis at 100%, so bureaus clearing backlog above 100% all pinned to the right edge at the same position — the axis now scales past 100% to fit the highest rate. ([#57](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/57))
 - **v1.1.0**: Layout and estimator fixes —
   - The formula breakdown listed its steps in reverse — the final calculation was shown first, ahead of the values it depends on

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp_immigration_dashboard",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "overrides": {

--- a/src/components/bklit/charts/sankey/sankey-tooltip.tsx
+++ b/src/components/bklit/charts/sankey/sankey-tooltip.tsx
@@ -33,6 +33,8 @@ export interface SankeyTooltipProps {
   }) => React.ReactNode;
   /** Value formatter function */
   formatValue?: (value: number) => string;
+  /** Row label for the node value. Default: "Sessions" (local extension) */
+  valueLabel?: string;
   /** Custom class name */
   className?: string;
 }
@@ -41,6 +43,7 @@ export function SankeyTooltip({
   nodeContent,
   linkContent,
   formatValue = intFmt,
+  valueLabel = "Sessions",
   className = "",
 }: SankeyTooltipProps) {
   const {
@@ -93,7 +96,7 @@ export function SankeyTooltip({
     const rows: TooltipRow[] = [
       {
         color: "var(--chart-line-primary)",
-        label: "Sessions",
+        label: valueLabel,
         value: formatValue(totalValue),
       },
     ];

--- a/src/components/charts/OutcomesSankeyChart.tsx
+++ b/src/components/charts/OutcomesSankeyChart.tsx
@@ -114,7 +114,7 @@ export const OutcomesSankeyChart: React.FC<ImmigrationChartData> = ({ data, filt
             >
               <SankeyLink />
               <SankeyNode valueUnit="applications" showValueLabels={!isNarrow} />
-              <SankeyTooltip />
+              <SankeyTooltip valueLabel="Applications" />
             </SankeyChart>
           )}
         </div>


### PR DESCRIPTION
## Summary
Fixed the Outcomes Sankey chart's tooltip to correctly display "Applications" instead of "Sessions" when showing node values. The "Sessions" label was a leftover from the chart library's web-analytics defaults that wasn't appropriate for this immigration data context.

## Changes
- **SankeyTooltip component**: Added a new optional `valueLabel` prop (defaults to "Sessions") to make the tooltip's row label customizable, replacing the hardcoded "Sessions" string
- **OutcomesSankeyChart**: Updated to pass `valueLabel="Applications"` to the SankeyTooltip component
- **Version bump**: Updated package version from 1.1.1 to 1.1.2
- **Changelog**: Documented the fix

## Implementation Details
The fix maintains backward compatibility by providing a sensible default value ("Sessions") for the new `valueLabel` prop, allowing other uses of the SankeyTooltip component to work without modification while enabling context-specific labels where needed.

https://claude.ai/code/session_0172pgQFyoK7C47N4Z7JMFJi