### PR TITLE
Simplify v1.2.0 changelog: focus on completed work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Added
 
-- **v1.2.0**: Localization foundation — every string in the interface is now translatable —
-  - Text, ARIA labels, chart legends and tooltips, table headers, and empty and error states all come from a single catalogue file per language, so adding a language means writing one file rather than editing components. A partial translation is safe to ship: anything left out falls back to English instead of rendering blank
-  - Numbers, percentages, and dates follow the chosen language, including chart axis ticks and tooltips, and counted phrases ("6 months", "± 3 days") use real plural rules rather than an English "s". Chart y-axis labels also read better in English as a side effect — a million now shows as "1M" rather than "1000k"
-  - The language switcher is rebuilt but stays hidden until a language is actually translated — Japanese is still only a handful of strings. `?lang=ja` continues to work for testing
-  - Contributors can add a language without touching the app: a generated template lists every string to translate, and a language that declares itself finished is held to it — if a later release adds a string that language lacks, the build fails rather than quietly falling back. See `src/i18n/README.md`
+- **v1.2.0**: Groundwork for multiple languages —
+  - Chart y-axis labels read better in English as a side effect of this work: a million now shows as "1M" instead of "1000k"
+  - The language switcher is being rebuilt, but stays hidden until a language is actually ready — Japanese still only covers a handful of strings. `?lang=ja` continues to work for testing
+  - Full translations aren't ready yet, but the interface — text, tooltips, numbers, dates, and pluralization — is now built to support them, so more languages can follow without a rewrite
 - **v1.1.0**: Refinements on top of the Civic Glass redesign —
   - Processing Efficiency swapped to a ranked lollipop chart — bureaus ordered by completion rate, stem weight carrying intake volume, against a nationwide-rate guide line
   - A global airport toggle in the filter bar: one click removes the airport branch offices (Narita, Haneda, Kansai, Chubu) from every chart, stat, and table — nationwide totals shrink accordingly instead of quietly still counting them, and the toggle's icon crosses out while engaged


### PR DESCRIPTION
## Summary
Updated the CHANGELOG.md to provide a more accurate and concise description of the v1.2.0 release, shifting focus from aspirational localization goals to the actual groundwork completed in this version.

## Changes Made
- Reframed v1.2.0 description from "Localization foundation" to "Groundwork for multiple languages" to better reflect the current state
- Removed overly detailed claims about completed translation infrastructure that aren't yet fully realized
- Clarified that full translations aren't ready, but the technical foundation is in place
- Simplified language about the language switcher status and Japanese translation coverage
- Kept the concrete improvement (y-axis label formatting: "1M" vs "1000k") as a tangible benefit
- Removed reference to `src/i18n/README.md` contributor guidelines that may not be finalized

## Rationale
The original changelog entry made promises about translation-ready infrastructure and contributor workflows that go beyond what's actually shipped. This revision is more honest about the current state while still acknowledging the important groundwork that enables future language support without requiring a rewrite.

https://claude.ai/code/session_014Z4duKgdsGcWMaaqYrWU63