### PR TITLE
Extend proper-noun exemption to bureau.*.compact keys

### DIFF
--- a/src/i18n/__tests__/catalogue.test.ts
+++ b/src/i18n/__tests__/catalogue.test.ts
@@ -147,7 +147,8 @@ const LATIN_BY_DESIGN = new Set<string>([
  * actually happens (北海道, not "Hokkaido"). Applied only below, and only to
  * locales without a `SCRIPT_OF` entry.
  */
-const isRomanizedProperNoun = (key: string): boolean => key.startsWith('prefecture.') || /^bureau\.\d+$/.test(key);
+const isRomanizedProperNoun = (key: string): boolean =>
+  key.startsWith('prefecture.') || /^bureau\.\d+(\.compact)?$/.test(key);
 
 /** Strips placeholders, digits, and punctuation — what's left is prose, if any. */
 const proseOf = (value: string): string => value.replace(PLACEHOLDER, '').replace(/[\s\d\p{P}\p{S}]/gu, '');


### PR DESCRIPTION
## Summary
- Small follow-up to #62's `isRomanizedProperNoun` helper (added to exempt Japanese place-name romanizations shared verbatim across Latin-script locales from the "leaves nothing sitting at its English value by accident" check).
- The regex only matched the bare `bureau.\d+` key, not its new `.compact` sibling. For the city-only bureaus (Sapporo, Sendai, Shinagawa, Yokohama, Nagoya, Osaka, Kobe, Hiroshima, Takamatsu, Fukuoka, Naha), the only correct `.compact` value is the same city name — so every Latin-script locale that defines it would fail the check the moment it's added, with no way to satisfy it via translation (there's no distinct "French" spelling of Sapporo).
- Fix: `/^bureau\.\d+$/` → `/^bureau\.\d+(\.compact)?$/`.
- Verified against a throwaway fixture before opening this: `bureau.101010.compact` (a bare city name) failed on the unpatched regex and passes after; a genuinely-translated composite like the Narita Airport `.compact` passed both before and after, since a real translation there naturally differs from English.

## Test plan
- [x] `npx vitest run src/i18n` — 43/43 tests pass (no regression to the `ja` pack)
- [x] `npx tsc --noEmit` — only the pre-existing, unrelated `../buildInfo` module error (a gitignored generated file, absent outside a full build)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCaopAXUTT6VfrFLuAuUu3)_