### PR TITLE
Add localization guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing! This document provides guidelines a
 - [Getting Started](#getting-started)
 - [Development Workflow](#development-workflow)
 - [Coding Guidelines](#coding-guidelines)
+- [Localization](#localization)
 - [Testing](#testing)
 - [Documentation](#documentation)
 - [Submitting Changes](#submitting-changes)
@@ -162,6 +163,39 @@ src/
 ├── i18n/             # Locale catalogues, translation runtime, and formatters
 └── lib/              # Small shared helpers (class-merge, motion)
 ```
+
+## Localization
+
+Every user-visible string lives in a per-language catalogue under
+`src/i18n/locales/`, so adding or fixing a translation is a content change,
+not a code change — see [`src/i18n/README.md`](src/i18n/README.md) for the
+full guide to the catalogue format, plurals, and the three name widths
+(`.label`/`.compact`/`.short`).
+
+### Correcting a translation
+
+English is written and reviewed by hand. Every other locale started from a
+machine translation, and while each pack was checked for structural
+correctness (every key present, placeholders intact, right plural forms),
+that check can't catch wrong terminology, awkward phrasing, or a mistranslated
+nuance — only a fluent reader will spot those. If you find one:
+
+1. Open `src/i18n/locales/<code>.ts` and fix the line(s) in question.
+2. Run `npx vitest run src/i18n` to confirm the catalogue tests still pass
+   (placeholders preserved, no accidental blank values, script check for
+   non-Latin locales).
+3. Open a PR as described below. A one- or two-line wording fix doesn't need
+   an issue first — that requirement is for larger changes. Explain what was
+   wrong and why your replacement is correct; if you're not a fluent speaker
+   of the language, say so, so reviewers know to look for a second opinion.
+
+If you'd rather flag a mistake than fix it yourself, open a
+[bug report issue](https://github.com/RetroHazard/JP_Immigration_Dashboard/issues/new?template=bug_report.md)
+naming the language, the key or on-screen text, and what it should say
+instead.
+
+Adding a language you don't see listed follows the same catalogue file
+mechanism — the step-by-step is in `src/i18n/README.md`, not repeated here.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
This PR adds a new "Localization" section to the CONTRIBUTING.md file to document how contributors should handle translations and localization in the project.

## Changes
- Added "Localization" to the table of contents in CONTRIBUTING.md
- Created a new "Localization" section that covers:
  - Overview of the localization system (per-language catalogues in `src/i18n/locales/`)
  - Reference to the detailed catalogue format guide in `src/i18n/README.md`
  - Step-by-step instructions for correcting translations, including:
    - How to locate and fix translation strings
    - How to run tests to validate changes (`npx vitest run src/i18n`)
    - Guidelines for PR submission and explanation requirements
  - Information about reporting translation issues via bug reports
  - Note that adding new languages follows the same mechanism documented in `src/i18n/README.md`

## Details
The new section clarifies that translations are content changes rather than code changes, and provides clear guidance for both fixing existing translations and adding new languages. It emphasizes the importance of fluent speakers reviewing translations and provides a structured workflow for contributors to follow.

https://claude.ai/code/session_01KUjHsvR76c77bH7C6UB3Gc