### PR TITLE
Format chart date labels and tooltips with month-year format

### DIFF
--- a/src/components/charts/CategorySubmissionsLineChart.tsx
+++ b/src/components/charts/CategorySubmissionsLineChart.tsx
@@ -33,7 +33,7 @@ const SERIES = [
 ] as const;
 
 export const CategorySubmissionsLineChart: React.FC<ImmigrationChartData> = ({ data, filters, range }) => {
-  const { t } = useLocale();
+  const { t, formatters } = useLocale();
   const series = useMemo(() => SERIES.map((entry) => ({ ...entry, label: t(entry.labelKey) })), [t]);
   const [hiddenSeries, setHiddenSeries] = useState<ReadonlySet<string>>(() => new Set());
   const toggleSeries = (id: string) =>
@@ -85,7 +85,13 @@ export const CategorySubmissionsLineChart: React.FC<ImmigrationChartData> = ({ d
           role="img"
           aria-label={t('charts.types.aria')}
         >
-          <LineChart data={chartData} aspectRatio="16 / 8">
+          <LineChart
+            data={chartData}
+            aspectRatio="16 / 8"
+            // Monthly points are all on the 1st — the default month+day labels
+            // drop the year, which is ambiguous across multi-year ranges.
+            formatDateLabel={(date) => formatters.monthYear(date)}
+          >
             <Grid horizontal />
             <YAxis />
             {visibleSeries.map((entry) => (
@@ -102,6 +108,7 @@ export const CategorySubmissionsLineChart: React.FC<ImmigrationChartData> = ({ d
             {/* Rows are named explicitly: the tooltip would otherwise show the
                 raw series ids now that those are no longer display text. */}
             <ChartTooltip
+              titleFormat={(date) => formatters.monthYear(date)}
               rows={(point) =>
                 visibleSeries.map((entry) => ({
                   color: entry.color,

--- a/src/components/charts/IntakeProcessingBarChart.tsx
+++ b/src/components/charts/IntakeProcessingBarChart.tsx
@@ -33,7 +33,7 @@ const SERIES = [
 ] as const;
 
 export const IntakeProcessingBarChart: React.FC<ImmigrationChartData> = ({ data, filters, range }) => {
-  const { t } = useLocale();
+  const { t, formatters } = useLocale();
   const series = useMemo(() => SERIES.map((entry) => ({ ...entry, label: t(entry.labelKey) })), [t]);
   const chartData = useMemo(() => {
     const months = monthsForRange(getAllMonths(data), range);
@@ -60,7 +60,16 @@ export const IntakeProcessingBarChart: React.FC<ImmigrationChartData> = ({ data,
         role="img"
         aria-label={t('charts.intake.aria')}
       >
-        <ComposedChart data={chartData} stacked stackGap={2} maxBarSize={30} aspectRatio="16 / 8">
+        <ComposedChart
+          data={chartData}
+          stacked
+          stackGap={2}
+          maxBarSize={30}
+          aspectRatio="16 / 8"
+          // Monthly points are all on the 1st — the default month+day labels
+          // drop the year, which is ambiguous across multi-year ranges.
+          formatDateLabel={(date) => formatters.monthYear(date)}
+        >
           <Grid horizontal />
           <YAxis />
           <SeriesBar dataKey="pending" fill="var(--chart-1)" />
@@ -70,6 +79,7 @@ export const IntakeProcessingBarChart: React.FC<ImmigrationChartData> = ({ data,
           {/* Rows are named explicitly: the tooltip would otherwise show the
               raw series ids now that those are no longer display text. */}
           <ChartTooltip
+            titleFormat={(date) => formatters.monthYear(date)}
             rows={(point) =>
               series.map((entry) => ({
                 color: entry.color,


### PR DESCRIPTION
## Summary
Updated two chart components to display dates in a consistent month-year format, improving clarity for multi-year date ranges by explicitly showing the year alongside the month.

## Key Changes
- **IntakeProcessingBarChart**: Added `formatters.monthYear()` formatting to both the chart's `formatDateLabel` prop and the `ChartTooltip`'s `titleFormat` prop
- **CategorySubmissionsLineChart**: Applied the same month-year formatting to the `LineChart`'s `formatDateLabel` prop and the `ChartTooltip`'s `titleFormat` prop
- Updated both components to destructure `formatters` from the `useLocale()` hook alongside the existing `t` function

## Implementation Details
- The formatting change addresses an issue where the default month+day labels would drop the year, creating ambiguity when displaying data across multi-year ranges
- Since all monthly data points are on the 1st of each month, the month-year format provides clearer temporal context without redundant day information
- The same formatter is applied consistently to both axis labels and tooltip titles within each chart for a unified user experience

https://claude.ai/code/session_01GA7QVzk9wtbizW6Qs9nYXF