### PR TITLE
Name every world region in the catalogue, not just Stateless (v1.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Fixed
 
+- **v1.4.2**: World regions showed up as raw codes — `region.1000` instead of "Asia" — on Chrome and Edge, in every language. It affected the Resident Flows sankey's left column, the region filter, Population Growth's by-region view, and the Residence Status sunburst; "Stateless" was the only region that read correctly —
+  - Continent names were being taken from the browser's own locale data, the same as country names. That works for countries everywhere, but Chrome and Edge ship no names for continents specifically, so they handed back the code they were given. Firefox and Safari were unaffected, which is what kept this out of sight
+  - All seven regions are now written into each of the twelve translations, so they read the same whichever browser you use
 - **v1.4.1**: The Intake & Processing and Application Types charts' axis labels and tooltips showed only month and day, dropping the year — ambiguous once a range spans more than one year, since every January looked the same. Both now show month and year instead.
 - **v1.2.6**: Chart axis numbers could render as clipped or outright wrong values in German, Portuguese, Spanish, and Italian — repeated "0.000" ticks, a leading digit sheared off ("800 mil" reading as "00 mil"), or no labels at all on narrow screens. Two causes stacked together: a CSS rule was silently re-clipping an intentional label overflow, and the axis margin was sized for English-length numbers ("1.2M") rather than the wider forms other locales use ("1,2 Mio.", "800 mil"). The margin now measures each locale's actual label width instead of assuming one —
   - Longer translations in KPI cards, the processing-time estimator heading, and the approval-rate gauge caption no longer lose characters at cramped widths — they wrap instead of silently truncating, or were shortened where that read better

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Japan Immigration Statistics Dashboard
-[![Version](https://img.shields.io/badge/version-1.4.1-blue.svg)](https://github.com/RetroHazard/JP_Immigration_Dashboard/releases)
+[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/RetroHazard/JP_Immigration_Dashboard/releases)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "overrides": {

--- a/src/constants/nationalities.ts
+++ b/src/constants/nationalities.ts
@@ -67,12 +67,16 @@ export const STATELESS = '7000';
 export const NATIONALITY_REGIONS = [...NATIONALITY_ROLLUP_REGIONS, STATELESS] as const;
 
 /**
- * UN M49 codes for the continent rollups. Intl.DisplayNames localizes these
- * the same way it does country codes, so the six continent names come from
- * ICU rather than the catalogue — including e-Stat's 北アメリカ, which spans
- * Central America and the Caribbean and so is M49 003 (the continent) rather
- * than 021 (Northern America). 無国籍 has no M49 equivalent and falls back to
- * `region.7000`.
+ * UN M49 codes for the continent rollups, including e-Stat's 北アメリカ, which
+ * spans Central America and the Caribbean and so is M49 003 (the continent)
+ * rather than 021 (Northern America). 無国籍 has no M49 equivalent at all.
+ *
+ * `useRegionLabel` tries these through Intl.DisplayNames first, but they are
+ * not a substitute for catalogue entries: Chrome and Edge ship no display
+ * names for M49 macro-regions, so `.of('142')` hands back '142' instead of
+ * "Asia" and the label falls through to `region.*`. Node and Firefox do
+ * resolve them, which is why this only ever showed up in the browser. Every
+ * region therefore has a catalogue entry in all thirteen locales.
  */
 export const REGION_M49: Record<string, string> = {
   '1000': '142', // Asia

--- a/src/i18n/__tests__/catalogue.test.ts
+++ b/src/i18n/__tests__/catalogue.test.ts
@@ -157,9 +157,22 @@ const isRomanizedProperNoun = (key: string): boolean =>
  * oversight — each entry here has to be argued for individually.
  *
  * Only place names so far: Spanish spells the former Yugoslavia exactly as
- * English does.
+ * English does, and several continents are spelled the English way across the
+ * Romance languages and Tagalog — "Asia" is Spanish and Italian for Asia,
+ * "Europe" is French for Europe, "Africa" is Italian and Tagalog for Africa,
+ * and "Oceania" is Italian, Portuguese and Tagalog for Oceania.
  */
-const IDENTICAL_BY_DESIGN = new Set<string>(['es:nationality.2500']);
+const IDENTICAL_BY_DESIGN = new Set<string>([
+  'es:nationality.2500',
+  'es:region.1000',
+  'fr:region.2000',
+  'it:region.1000',
+  'it:region.3000',
+  'it:region.6000',
+  'pt:region.6000',
+  'tl:region.3000',
+  'tl:region.6000',
+]);
 
 /** Strips placeholders, digits, and punctuation — what's left is prose, if any. */
 const proseOf = (value: string): string => value.replace(PLACEHOLDER, '').replace(/[\s\d\p{P}\p{S}]/gu, '');

--- a/src/i18n/__tests__/useResidentLabels.test.tsx
+++ b/src/i18n/__tests__/useResidentLabels.test.tsx
@@ -1,9 +1,11 @@
 // src/i18n/__tests__/useResidentLabels.test.tsx
-// Nationality and continent names come from ICU rather than the catalogue, so
-// what needs asserting here is different from the other domain hooks: that the
-// ISO/M49 codes actually resolve, that the handful with no such identity fall
+// Nationality and continent names are resolved from ICU before the catalogue,
+// so what needs asserting here is different from the other domain hooks: that
+// the ISO/M49 codes actually resolve, that the rows with no such identity fall
 // through to their catalogue entry, and that neither path ever leaks a bare
-// code into the UI.
+// code into the UI. The continents need covering on both paths — ICU names
+// them under vitest but not in every browser, so only the fallback is load-
+// bearing in Chrome.
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { nationalities } from '../../constants/nationalities';
@@ -104,6 +106,20 @@ describe('resident label hooks', () => {
     expect(screen.getByTestId('china').textContent).toBe('中国');
     expect(screen.getByTestId('asia').textContent).toBe('アジア');
     expect(screen.getByTestId('stateless').textContent).toBe('無国籍');
+  });
+
+  it('names the continents on an engine with no M49 display names', () => {
+    // The regression behind the `region.1000` labels: Chrome and Edge ship
+    // Intl.DisplayNames but no macro-region data, so `.of('142')` returns
+    // '142' rather than throwing. Node and Firefox resolve it, which is why
+    // the assertions above pass under vitest while the browser showed keys.
+    vi.spyOn(Intl, 'DisplayNames').mockImplementation(
+      () => ({ of: (code: string) => code }) as unknown as Intl.DisplayNames
+    );
+    renderProbe('en');
+    expect(screen.getByTestId('asia').textContent).toBe('Asia');
+    expect(screen.getByTestId('northAmerica').textContent).toBe('North America');
+    expect(screen.getByTestId('stateless').textContent).toBe('Stateless');
   });
 
   it('degrades to the catalogue when Intl.DisplayNames is unavailable', () => {

--- a/src/i18n/locales/_template.ts
+++ b/src/i18n/locales/_template.ts
@@ -446,10 +446,13 @@ export const template: Dictionary = {
   // 'prefecture.47': 'Okinawa',
 
   // ── Resident population dataset ──────────────────────────────────────────
-  // Nationality and region names are NOT here: they come from
-  // Intl.DisplayNames via the ISO/M49 codes in constants/nationalities.ts, so
-  // all thirteen locales get them without a catalogue entry apiece. Only the
-  // handful of rows with no ISO identity are listed under `nationality.*`.
+  // Nationality names are NOT here: they come from Intl.DisplayNames via the
+  // ISO codes in constants/nationalities.ts, so all thirteen locales get them
+  // without a catalogue entry apiece. Only the handful of rows with no ISO
+  // identity are listed under `nationality.*`.
+  // The `region.*` continents ARE all listed: ICU is still tried first via
+  // REGION_M49, but Chrome ships no display names for M49 macro-regions, so
+  // the catalogue has to be able to name every one of them. See below.
   // 'dataset.label': 'Dataset',
   // 'dataset.aria': 'Choose which dataset to explore',
   // 'dataset.processing': 'Application Processing',
@@ -546,8 +549,20 @@ export const template: Dictionary = {
   // 'statusGroup.residency': 'Residency',
   // 'statusGroup.other': 'Other',
 
-  // Only the rows with no ISO 3166-1 identity; everything else is ICU.
+  // Every continent rollup: `Intl.DisplayNames` is tried first, but Chrome and
+  // Edge ship no names for UN M49 macro-regions (`.of('142')` gives back '142',
+  // not "Asia"), so these are what actually renders there. 4000 is M49 003 —
+  // e-Stat's 北アメリカ spans Central America and the Caribbean, so it is
+  // "North America", not 021's "Northern America". 7000 has no M49 code at all.
+  // 'region.1000': 'Asia',
+  // 'region.2000': 'Europe',
+  // 'region.3000': 'Africa',
+  // 'region.4000': 'North America',
+  // 'region.5000': 'South America',
+  // 'region.6000': 'Oceania',
   // 'region.7000': 'Stateless',
+
+  // Only the rows with no ISO 3166-1 identity; everything else is ICU.
   // 'nationality.1120': 'Korea (Chosen)',
   // 'nationality.1130': 'Korea (combined)',
   // 'nationality.2290': 'Serbia and Montenegro',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -523,8 +523,16 @@ export const de: Dictionary = {
   'statusGroup.family': 'Familie',
   'statusGroup.residency': 'Niederlassung',
   'statusGroup.other': 'Sonstige',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Asien',
+  'region.2000': 'Europa',
+  'region.3000': 'Afrika',
+  'region.4000': 'Nordamerika',
+  'region.5000': 'Südamerika',
+  'region.6000': 'Ozeanien',
   'region.7000': 'Staatenlos',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Korea (Chosen-Registrierung)',
   'nationality.1130': 'Korea (zusammengefasst)',
   'nationality.2290': 'Serbien und Montenegro',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -434,10 +434,13 @@ export const en = {
   'prefecture.47': 'Okinawa',
 
   // ── Resident population dataset ──────────────────────────────────────────
-  // Nationality and region names are NOT here: they come from
-  // Intl.DisplayNames via the ISO/M49 codes in constants/nationalities.ts, so
-  // all thirteen locales get them without a catalogue entry apiece. Only the
-  // handful of rows with no ISO identity are listed under `nationality.*`.
+  // Nationality names are NOT here: they come from Intl.DisplayNames via the
+  // ISO codes in constants/nationalities.ts, so all thirteen locales get them
+  // without a catalogue entry apiece. Only the handful of rows with no ISO
+  // identity are listed under `nationality.*`.
+  // The `region.*` continents ARE all listed: ICU is still tried first via
+  // REGION_M49, but Chrome ships no display names for M49 macro-regions, so
+  // the catalogue has to be able to name every one of them. See below.
   'dataset.label': 'Dataset',
   'dataset.aria': 'Choose which dataset to explore',
   'dataset.processing': 'Application Processing',
@@ -534,8 +537,20 @@ export const en = {
   'statusGroup.residency': 'Residency',
   'statusGroup.other': 'Other',
 
-  // Only the rows with no ISO 3166-1 identity; everything else is ICU.
+  // Every continent rollup: `Intl.DisplayNames` is tried first, but Chrome and
+  // Edge ship no names for UN M49 macro-regions (`.of('142')` gives back '142',
+  // not "Asia"), so these are what actually renders there. 4000 is M49 003 —
+  // e-Stat's 北アメリカ spans Central America and the Caribbean, so it is
+  // "North America", not 021's "Northern America". 7000 has no M49 code at all.
+  'region.1000': 'Asia',
+  'region.2000': 'Europe',
+  'region.3000': 'Africa',
+  'region.4000': 'North America',
+  'region.5000': 'South America',
+  'region.6000': 'Oceania',
   'region.7000': 'Stateless',
+
+  // Only the rows with no ISO 3166-1 identity; everything else is ICU.
   'nationality.1120': 'Korea (Chosen)',
   'nationality.1130': 'Korea (combined)',
   'nationality.2290': 'Serbia and Montenegro',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -525,8 +525,16 @@ export const es: Dictionary = {
   'statusGroup.family': 'Familia',
   'statusGroup.residency': 'Residencia',
   'statusGroup.other': 'Otros',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Asia',
+  'region.2000': 'Europa',
+  'region.3000': 'África',
+  'region.4000': 'América del Norte',
+  'region.5000': 'América del Sur',
+  'region.6000': 'Oceanía',
   'region.7000': 'Apátrida',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Corea (Chosen)',
   'nationality.1130': 'Corea (agrupada)',
   'nationality.2290': 'Serbia y Montenegro',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -523,8 +523,16 @@ export const fr: Dictionary = {
   'statusGroup.family': 'Famille',
   'statusGroup.residency': 'Résidence',
   'statusGroup.other': 'Autres',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Asie',
+  'region.2000': 'Europe',
+  'region.3000': 'Afrique',
+  'region.4000': 'Amérique du Nord',
+  'region.5000': 'Amérique du Sud',
+  'region.6000': 'Océanie',
   'region.7000': 'Apatride',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Corée (Chosen)',
   'nationality.1130': 'Corée (regroupée)',
   'nationality.2290': 'Serbie-et-Monténégro',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -527,8 +527,16 @@ export const it: Dictionary = {
   'statusGroup.family': 'Famiglia',
   'statusGroup.residency': 'Residenza',
   'statusGroup.other': 'Altro',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Asia',
+  'region.2000': 'Europa',
+  'region.3000': 'Africa',
+  'region.4000': 'America del Nord',
+  'region.5000': 'America del Sud',
+  'region.6000': 'Oceania',
   'region.7000': 'Apolide',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Corea (Chosen)',
   'nationality.1130': 'Corea (aggregata)',
   'nationality.2290': 'Serbia e Montenegro',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -524,8 +524,16 @@ export const ja: Dictionary = {
   'statusGroup.family': '家族',
   'statusGroup.residency': '居住',
   'statusGroup.other': 'その他',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'アジア',
+  'region.2000': 'ヨーロッパ',
+  'region.3000': 'アフリカ',
+  'region.4000': '北アメリカ',
+  'region.5000': '南アメリカ',
+  'region.6000': 'オセアニア',
   'region.7000': '無国籍',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': '朝鮮',
   'nationality.1130': '韓国・朝鮮',
   'nationality.2290': 'セルビア・モンテネグロ',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -534,8 +534,16 @@ export const ko: Dictionary = {
   'statusGroup.family': '가족',
   'statusGroup.residency': '거주',
   'statusGroup.other': '기타',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': '아시아',
+  'region.2000': '유럽',
+  'region.3000': '아프리카',
+  'region.4000': '북아메리카',
+  'region.5000': '남아메리카',
+  'region.6000': '오세아니아',
   'region.7000': '무국적',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': '조선적',
   'nationality.1130': '한국・조선 합계',
   'nationality.2290': '세르비아 몬테네그로',

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -527,8 +527,16 @@ export const pt: Dictionary = {
   'statusGroup.family': 'Família',
   'statusGroup.residency': 'Residência',
   'statusGroup.other': 'Outros',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Ásia',
+  'region.2000': 'Europa',
+  'region.3000': 'África',
+  'region.4000': 'América do Norte',
+  'region.5000': 'América do Sul',
+  'region.6000': 'Oceania',
   'region.7000': 'Apátrida',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Coreia (Chosen)',
   'nationality.1130': 'Coreia (agregada)',
   'nationality.2290': 'Sérvia e Montenegro',

--- a/src/i18n/locales/tl.ts
+++ b/src/i18n/locales/tl.ts
@@ -539,8 +539,16 @@ export const tl: Dictionary = {
   'statusGroup.family': 'Pamilya',
   'statusGroup.residency': 'Paninirahan',
   'statusGroup.other': 'Iba pa',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Asya',
+  'region.2000': 'Europa',
+  'region.3000': 'Africa',
+  'region.4000': 'Hilagang Amerika',
+  'region.5000': 'Timog Amerika',
+  'region.6000': 'Oceania',
   'region.7000': 'Walang bansa',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Korea (rehistrong Chosen)',
   'nationality.1130': 'Korea (pinagsama)',
   'nationality.2290': 'Serbia at Montenegro',

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -543,8 +543,16 @@ export const vi: Dictionary = {
   'statusGroup.family': 'Gia đình',
   'statusGroup.residency': 'Định cư',
   'statusGroup.other': 'Khác',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': 'Châu Á',
+  'region.2000': 'Châu Âu',
+  'region.3000': 'Châu Phi',
+  'region.4000': 'Bắc Mỹ',
+  'region.5000': 'Nam Mỹ',
+  'region.6000': 'Châu Đại Dương',
   'region.7000': 'Không quốc tịch',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': 'Triều Tiên (Chosen)',
   'nationality.1130': 'Hàn Quốc và Triều Tiên (gộp)',
   'nationality.2290': 'Serbia và Montenegro',

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -532,8 +532,16 @@ export const zhCn: Dictionary = {
   'statusGroup.family': '家庭',
   'statusGroup.residency': '居住',
   'statusGroup.other': '其他',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': '亚洲',
+  'region.2000': '欧洲',
+  'region.3000': '非洲',
+  'region.4000': '北美洲',
+  'region.5000': '南美洲',
+  'region.6000': '大洋洲',
   'region.7000': '无国籍',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': '朝鲜籍',
   'nationality.1130': '韩国・朝鲜合计',
   'nationality.2290': '塞尔维亚和黑山',

--- a/src/i18n/locales/zh-tw.ts
+++ b/src/i18n/locales/zh-tw.ts
@@ -544,8 +544,16 @@ export const zhTw: Dictionary = {
   'statusGroup.family': '家庭',
   'statusGroup.residency': '居住',
   'statusGroup.other': '其他',
-  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
+  // ── World regions. ICU is tried first, but Chrome ships no names for M49
+  // macro-regions, so these are what actually renders there. ────────────────
+  'region.1000': '亞洲',
+  'region.2000': '歐洲',
+  'region.3000': '非洲',
+  'region.4000': '北美洲',
+  'region.5000': '南美洲',
+  'region.6000': '大洋洲',
   'region.7000': '無國籍',
+  // ── Nationalities with no ISO identity (everything else is ICU) ─────────
   'nationality.1120': '朝鮮籍',
   'nationality.1130': '韓國・朝鮮合計',
   'nationality.2290': '塞爾維亞及蒙特內哥羅',


### PR DESCRIPTION
## Summary

World regions rendered as raw catalogue keys — `region.1000` instead of "Asia" — on Chrome and Edge, in every language. `Stateless` was the only one that read correctly.

## Root cause

`useRegionLabel` resolves the six continent rollups through `Intl.DisplayNames` using the UN M49 codes in `REGION_M49`, falling back to `t('region.<code>')`:

```ts
const m49 = REGION_M49[code];              // '1000' -> '142'
if (m49 && display) {
  const name = display.of(m49);
  if (name && name !== m49) return name;   // Chrome: '142' === '142' -> no
}
return t(`region.${code}` as DictionaryKey);
```

**Chrome and Edge ship no display names for UN M49 macro-regions.** Verified against Chromium 1194:

```
Intl.DisplayNames(['en-US'],{type:'region'}).of('142') -> '142'   // not "Asia"
Intl.DisplayNames(['en-US'],{type:'region'}).of('US')  -> 'United States'
```

`.of()` hands the code straight back, the `name !== m49` guard rejects it, and the label falls through to a catalogue that only defined `region.7000`. A missing key renders as itself, so the raw key reached the chart.

Node and Firefox **do** resolve these codes. That is why `useResidentLabels.test.tsx` asserts `'Asia'` and passes under vitest while the browser showed keys — the suite only ever exercised an engine that has the data.

This also explains why node colours stayed correct: `REGION_COLOR` is keyed by the same clean `'1000'` codes, so the codes themselves were never wrong.

### Not the data pipeline

Ruled out directly. `buildResidentFlows` derives the region from `nationalityByCode(record.nationality)?.region` — from the `nationalities.ts` constants, never from `residents.json`, which has no region dimension at all. Re-running `transform-data.mts` against the raw e-Stat payloads reproduces the shipped `residents.json` and `dashboard.json` byte for byte (matching md5s).

## Scope

`useRegionLabel` / `useRegionOptions` also back the region filter (`ResidentFilterPanel`), `PopulationGrowthChart`, and `ResidenceStatusSunburst`. All were showing raw keys on Chrome; all are fixed by the same change.

## Changes

- **`region.1000`–`region.6000` added to all twelve locales**, beside the existing `region.7000`, plus the regenerated `_template.ts`. `useRegionLabel` itself is unchanged — its fallback was already correct, it just had nothing to fall back to. ICU stays the primary path where it works.
- **`4000` is M49 003**, not 021: e-Stat's 北アメリカ spans Central America and the Caribbean, so it is "North America" rather than "Northern America". Preserved in every locale.
- **Regression test** in `useResidentLabels.test.tsx`. The existing case mocks `Intl.DisplayNames` into *throwing*, which the code already survived; the new one mocks the shape Chrome actually has — `of()` present, returning its input — which fails without the catalogue entries.
- **`IDENTICAL_BY_DESIGN` extended** in `catalogue.test.ts`. It fails any locale value identical to English, and eight continent names legitimately are: "Asia" in Spanish and Italian, "Europe" in French, "Africa" in Italian and Tagalog, "Oceania" in Italian, Portuguese and Tagalog. Allowlisted with the reasoning rather than given artificial differences.
- **Comments corrected** in `constants/nationalities.ts` and `locales/en.ts`, both of which asserted regions came from ICU alone.
- **v1.4.2**: `package.json`, README badge, CHANGELOG.

### Trade-off

ICU remains primary, so engines that have M49 data keep rendering ICU's wording while Chrome renders the catalogue's. These can differ slightly — ja gives `北アメリカ大陸` from ICU vs `北アメリカ` from the catalogue. Catalogue values were chosen to match ICU's common wording where reasonable to keep that gap small.

## Verification

- `npx vitest run` — 283 passing (27 files); `npm run lint` and `npm run typecheck` clean.
- Drove real Chromium over CDP against `next dev` with the actual e-Stat data. The sankey's left column now reads Asia / South America / Europe / North America / Africa / Oceania / Stateless, and `?lang=ja` gives アジア / 南アメリカ / ヨーロッパ / 北アメリカ / アフリカ / オセアニア / 無国籍.

Note that `npm run typecheck` needs `npx react-build-info` to have run first, or it fails on a missing `../buildInfo` — pre-existing and unrelated.