### PR TITLE
Add GitHub repository link to navigation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Added
 
+- **v1.4.4**: The header now links to the project's source repository, next to the theme toggle on desktop and under About in the mobile settings drawer
+
 - **v1.4.0**: Three more views join the Resident Population dataset, alongside a filtering overhaul —
   - **Population Growth** stacks total foreign residents per half-year since 2012, toggleable between purpose-of-stay and world-region breakdowns, with markers for policy changes and the COVID-19 dip
   - **Resident Flows** is a three-column sankey — region into country into purpose-of-stay group — showing the full nationality × status cross-tabulation for a single snapshot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "homepage": "https://dashboard.retrohazard.jp",
   "private": true,
   "overrides": {

--- a/src/components/DashboardShell.tsx
+++ b/src/components/DashboardShell.tsx
@@ -12,7 +12,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
 import { animate, stagger } from 'animejs';
-import { Calculator, ChevronsLeft, History, Menu, Moon, Sun } from 'lucide-react';
+import { Calculator, ChevronsLeft, ExternalLink, History, Menu, Moon, Sun } from 'lucide-react';
 import { createParser, parseAsBoolean, parseAsStringLiteral, useQueryState } from 'nuqs';
 import type React from 'react';
 
@@ -52,6 +52,7 @@ import { CHART_KEYS, CHARTS_BY_DATASET, datasetForChart,DATASETS } from './commo
 import { LanguageSwitcher } from './common/LanguageSwitcher';
 import { PeriodSelector } from './common/PeriodSelector';
 import { SnapshotPeriodSelector } from './common/SnapshotPeriodSelector';
+import { GitHubIcon } from './icons/GitHubIcon';
 import { ActiveChart } from './ActiveChart';
 import { ChangelogModal } from './ChangelogModal';
 import { ChartDataTable } from './ChartDataTable';
@@ -60,6 +61,8 @@ import { FilterPanel } from './FilterPanel';
 import { ResidentFilterPanel } from './ResidentFilterPanel';
 import { ResidentsStatsSummary } from './ResidentsStatsSummary';
 import { StatsSummary } from './StatsSummary';
+
+const REPO_URL = 'https://github.com/RetroHazard/JP_Immigration_Dashboard';
 
 const BUREAU_VALUES = bureauOptions.map((option) => option.value);
 const TYPE_VALUES = applicationOptions.map((option) => option.value);
@@ -314,6 +317,15 @@ export const DashboardShell: React.FC<DashboardShellProps> = ({ data, meta, resi
                 <History className="size-3.5" aria-hidden="true" />
                 {t('nav.version', { version: buildInfo.buildVersion })}
               </button>
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={t('nav.sourceCode')}
+                className="hidden size-9 items-center justify-center rounded-full border border-border text-secondary-foreground transition-colors hover:bg-muted sm:flex"
+              >
+                <GitHubIcon className="size-4" />
+              </a>
               <button
                 onClick={toggleTheme}
                 aria-label={t(isDarkMode ? 'nav.switchToLightTheme' : 'nav.switchToDarkTheme')}
@@ -389,6 +401,19 @@ export const DashboardShell: React.FC<DashboardShellProps> = ({ data, meta, resi
                           {t('nav.version', { version: buildInfo.buildVersion })}
                         </span>
                       </button>
+                      <a
+                        href={REPO_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                        onClick={() => setIsMenuOpen(false)}
+                        className="mt-2 flex w-full items-center justify-between rounded-lg border border-border px-3 py-2 text-sm text-secondary-foreground transition-colors hover:bg-muted"
+                      >
+                        <span className="flex items-center gap-2">
+                          <GitHubIcon className="size-4" />
+                          {t('nav.sourceCode')}
+                        </span>
+                        <ExternalLink className="size-3.5 text-muted-foreground" aria-hidden="true" />
+                      </a>
                     </section>
                   </div>
                 </SheetContent>

--- a/src/components/icons/GitHubIcon.tsx
+++ b/src/components/icons/GitHubIcon.tsx
@@ -1,0 +1,13 @@
+// src/components/icons/GitHubIcon.tsx
+// lucide dropped brand glyphs before 1.x, so the GitHub mark is vendored from
+// Iconify's simple-icons set (CC0) rather than adding a second icon library.
+// The props mirror how lucide icons are used here — a `size-*` class and
+// currentColor — so it drops into the header alongside them.
+
+export function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}

--- a/src/i18n/locales/_template.ts
+++ b/src/i18n/locales/_template.ts
@@ -53,6 +53,7 @@ export const template: Dictionary = {
   // 'nav.themeDark': 'Dark',
   // 'nav.about': 'About',
   // 'nav.changelog': 'Changelog',
+  // 'nav.sourceCode': 'Source code',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   // 'dashboard.dataCoverage': 'Data: {range}',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -38,6 +38,7 @@ export const de: Dictionary = {
   'nav.themeDark': 'Dunkel',
   'nav.about': 'Über',
   'nav.changelog': 'Änderungsprotokoll',
+  'nav.sourceCode': 'Quellcode',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Daten: {range}',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -41,6 +41,7 @@ export const en = {
   'nav.themeDark': 'Dark',
   'nav.about': 'About',
   'nav.changelog': 'Changelog',
+  'nav.sourceCode': 'Source code',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Data: {range}',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -37,6 +37,7 @@ export const es: Dictionary = {
   'nav.themeDark': 'Oscuro',
   'nav.about': 'Acerca de',
   'nav.changelog': 'Registro de cambios',
+  'nav.sourceCode': 'Código fuente',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Datos: {range}',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -36,6 +36,7 @@ export const fr: Dictionary = {
   'nav.themeDark': 'Sombre',
   'nav.about': 'À propos',
   'nav.changelog': 'Journal des modifications',
+  'nav.sourceCode': 'Code source',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Données : {range}',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -39,6 +39,7 @@ export const it: Dictionary = {
   'nav.themeDark': 'Scuro',
   'nav.about': 'Informazioni',
   'nav.changelog': 'Registro delle modifiche',
+  'nav.sourceCode': 'Codice sorgente',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Dati: {range}',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -49,6 +49,7 @@ export const ja: Dictionary = {
   'nav.themeDark': 'ダーク',
   'nav.about': 'このサイトについて',
   'nav.changelog': '更新履歴',
+  'nav.sourceCode': 'ソースコード',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': '対象期間：{range}',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -55,6 +55,7 @@ export const ko: Dictionary = {
   'nav.themeDark': '다크',
   'nav.about': '소개',
   'nav.changelog': '변경 이력',
+  'nav.sourceCode': '소스 코드',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': '데이터: {range}',

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -38,6 +38,7 @@ export const pt: Dictionary = {
   'nav.themeDark': 'Escuro',
   'nav.about': 'Sobre',
   'nav.changelog': 'Registo de alterações',
+  'nav.sourceCode': 'Código-fonte',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Dados: {range}',

--- a/src/i18n/locales/tl.ts
+++ b/src/i18n/locales/tl.ts
@@ -38,6 +38,7 @@ export const tl: Dictionary = {
   'nav.themeDark': 'Madilim',
   'nav.about': 'Tungkol Dito',
   'nav.changelog': 'Listahan ng Pagbabago',
+  'nav.sourceCode': 'Source Code',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Datos: {range}',

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -38,6 +38,7 @@ export const vi: Dictionary = {
   'nav.themeDark': 'Tối',
   'nav.about': 'Giới thiệu',
   'nav.changelog': 'Nhật ký thay đổi',
+  'nav.sourceCode': 'Mã nguồn',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': 'Dữ liệu: {range}',

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -54,6 +54,7 @@ export const zhCn: Dictionary = {
   'nav.themeDark': '深色',
   'nav.about': '关于本站',
   'nav.changelog': '更新日志',
+  'nav.sourceCode': '源代码',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': '数据范围：{range}',

--- a/src/i18n/locales/zh-tw.ts
+++ b/src/i18n/locales/zh-tw.ts
@@ -61,6 +61,7 @@ export const zhTw: Dictionary = {
   'nav.themeDark': '深色',
   'nav.about': '關於',
   'nav.changelog': '更新日誌',
+  'nav.sourceCode': '原始碼',
 
   // ── Dashboard chrome ─────────────────────────────────────────────────────
   'dashboard.dataCoverage': '資料範圍：{range}',


### PR DESCRIPTION
## Summary
This PR adds a link to the project's GitHub repository in the dashboard navigation, making it easy for users to access the source code. The link is displayed prominently in the header on desktop and integrated into the mobile menu.

## Key Changes
- **New GitHubIcon component** (`src/components/icons/GitHubIcon.tsx`): A vendored SVG icon from simple-icons (CC0) that mirrors lucide's styling conventions for seamless integration with existing icons
- **Navigation updates** (`src/components/DashboardShell.tsx`):
  - Desktop header: Icon-only link next to the theme toggle
  - Mobile menu: Full-width link with icon and external link indicator in the About section
  - Repository URL constant defined for easy maintenance
- **Internationalization**: Added `nav.sourceCode` translation key across all 11 supported languages (English, German, Spanish, French, Italian, Japanese, Korean, Portuguese, Tagalog, Vietnamese, Simplified Chinese, Traditional Chinese)
- **Version bump**: Updated to v1.4.4 and documented the feature in CHANGELOG.md

## Implementation Details
- The GitHub icon is vendored rather than adding a second icon library, keeping dependencies minimal
- Links open in a new tab with `target="_blank"` and `rel="noreferrer"` for security
- Responsive design: hidden on mobile (sm breakpoint), shown in menu instead
- Consistent styling with existing navigation elements using border, hover states, and proper contrast

https://claude.ai/code/session_014ySp8HrcXohtPSUwvkU7EY