### PR TITLE
Reorganize changelog entries and update version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,16 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
   - Existing links keep working exactly as they did — the dataset is worked out from the chart a link names, not from a new parameter
   - Views that only make sense for application processing — the processing-time estimator, the airport-office toggle, bureau comparison, and the data table — are hidden on this dataset rather than shown doing nothing
 
+- **v1.2.7**: Korean, Chinese (Simplified and Traditional), Vietnamese, and Tagalog join the six existing languages — twelve full translations end to end ([#69](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/69)) —
+  - Korean and both Chinese variants write bureau and prefecture names in their own script throughout, not romanized forms, the same standard Japanese already sets
+  - Tagalog is the only one of the twelve besides English that inflects for plural count; Korean, Chinese, and Vietnamese use one form regardless of count, the same as Japanese
+  - Numbers, dates, and pluralized phrases follow each language's own rules, the same as every other locale
+
 - **v1.2.5**: French, German, Italian, Portuguese, and Spanish join Japanese in full translation — the switcher now offers six languages end to end ([#69](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/69)) —
   - Every interface string is translated in all five: chart labels and tooltips, the data table, the estimator, and empty/error states, alongside the text already covered
   - Portuguese follows European usage (pt-PT) rather than Brazilian
   - Numbers, dates, and pluralized phrases follow each language's own rules, the same as every other locale
   - Bureau and application-type abbreviations (the terminal-style `CTS`, `EXT`-style codes) are left in Latin script where that's how each language actually renders them, rather than forced into an artificial translation
-- **v1.2.7**: Korean, Chinese (Simplified and Traditional), Vietnamese, and Tagalog join the six existing languages — twelve full translations end to end ([#69](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/69)) —
-  - Korean and both Chinese variants write bureau and prefecture names in their own script throughout, not romanized forms, the same standard Japanese already sets
-  - Tagalog is the only one of the twelve besides English that inflects for plural count; Korean, Chinese, and Vietnamese use one form regardless of count, the same as Japanese
-  - Numbers, dates, and pluralized phrases follow each language's own rules, the same as every other locale
 
 ### Changed
 
@@ -160,8 +161,8 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Fixed
 
-- **v0.4.2**: Simplified the estimation formula, fixing abnormal results that could occur when an application date shifted across a month boundary. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
 - **v0.4.3**: Fixed a double-counting bug in the processed-applications estimate.
+- **v0.4.2**: Simplified the estimation formula, fixing abnormal results that could occur when an application date shifted across a month boundary. ([#25](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/25))
 
 ## 2025-03
 
@@ -186,15 +187,15 @@ All notable user-facing changes to the Japan Immigration Bureaus Statistics Dash
 
 ### Added
 
-- Initial launch: application-intake bar chart, Estimation Card, Filter Panel, and Stats Summary, with a collapsible details pane showing the underlying formula.
+- **v0.2.2**: Follow-up UI polish.
 - **v0.2.1**: Mobile-first responsive design and dark mode —
   - Mobile-friendly layout with native breakpoints
   - Dark mode with a toggle switch
   - Drawer-style Estimation Card and tooltips on mobile
   ([#10](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/10))
-- **v0.2.2**: Follow-up UI polish.
+- Initial launch: application-intake bar chart, Estimation Card, Filter Panel, and Stats Summary, with a collapsible details pane showing the underlying formula.
 
 ### Fixed
 
-- **v0.1.1**: Added guidance text for the month picker on Safari (macOS), which didn't natively support that input type at the time; fixed the displayed "Last Updated" date so it reflects the actual build instead of updating every time the page loads.
 - **v0.1.2**: The Estimation Card no longer shows no details when an application's completion date is already past due. ([#5](https://github.com/RetroHazard/JP_Immigration_Dashboard/pull/5))
+- **v0.1.1**: Added guidance text for the month picker on Safari (macOS), which didn't natively support that input type at the time; fixed the displayed "Last Updated" date so it reflects the actual build instead of updating every time the page loads.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -376,6 +376,7 @@ JP_Immigration_Dashboard/
 │   ├── sync-changelog.js          # Copies CHANGELOG.md into public/
 │   ├── vendor-bklit.mjs           # Pulls Bklit UI registry items into the repo
 │   ├── vendor-world-topology.mjs  # One-shot vendoring of world-atlas into public/static
+│   ├── simplify-japan-topology.mjs # One-shot Visvalingam–Whyatt pass over public/static/japan.topo.json
 │   └── og-template.html
 │
 ├── package.json                   # Dependencies and scripts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Japan Immigration Statistics Dashboard
-[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/RetroHazard/JP_Immigration_Dashboard/releases)
+[![Version](https://img.shields.io/badge/version-1.5.0-blue.svg)](https://github.com/RetroHazard/JP_Immigration_Dashboard/releases)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jp_immigration_dashboard",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jp_immigration_dashboard",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",


### PR DESCRIPTION
## Summary
Sweep over the merged chart-optimizations rollup: syncs the two version files that were still lagging, documents the one script that was documented nowhere, and sorts the changelog into consistent newest-first order.

## Key Changes

- **Version metadata** — `package.json` was already at 1.5.0 (and drives the header via `buildInfo`), but two files that track the version had drifted and were never updated with it:
  - README version badge: 1.4.2 → 1.5.0
  - `package-lock.json`, both root `version` fields: 1.4.1 → 1.5.0

  Both were already stale before this rollup — `main` sat at 1.4.3 against the same 1.4.2/1.4.1 values — so this is long-standing drift, just wider now. `npm ci` is unaffected either way, and the lockfile stays in its shaken state.

- **Documentation** — added `scripts/simplify-japan-topology.mjs` to the DEVELOPMENT.md script inventory. It was the only script in `scripts/` documented nowhere, while its closest sibling `vendor-world-topology.mjs` is listed.

- **Changelog ordering** — most sections already ran newest-first; four entries across three sections did not, so a reader scanning down a section hit an older version and then a newer one again:

  | Section | Was | Now |
  |---|---|---|
  | 2026-08 / Added | v1.2.5 before v1.2.7 | v1.2.7, v1.2.5 |
  | 2025-04 / Fixed | v0.4.2 before v0.4.3 | v0.4.3, v0.4.2 |
  | 2025-01 / Added | Initial launch before v0.2.1, v0.2.2 | v0.2.2, v0.2.1, Initial launch |
  | 2025-01 / Fixed | v0.1.1 before v0.1.2 | v0.1.2, v0.1.1 |

## Notable Details

- The unversioned "Initial launch" entry moves to the end of its section, matching how 2025-10 and 2025-05 already trail unversioned entries after versioned ones.
- The unversioned **Japanese** entry in 2026-07 / Added deliberately stays at the top: it is the newest item in that month and carries a label rather than a version number, so sorting it to the bottom would bury the newest entry.
- The changelog change is a pure reordering — verified by set comparison against the previous revision, no text added, removed, or altered. The single added line is a blank separator between the two swapped entries, matching that section's spacing.

## Still Outstanding

Not addressed here, because it is an editorial call about release history: PRs #83 and #84 labelled their changelog entries **v1.4.4**, while #85 used **v1.5.0**. Since `main` goes 1.4.3 → 1.5.0, those three v1.4.4 entries describe a version that will never ship. Every other version in the changelog corresponds to a real release.

## Verification

`npm run lint`, `npm run typecheck`, `npx vitest run` (34 suites / 342 tests), and `npm run build` all pass locally on this branch, as does the CI lockfile-shaken check.

https://claude.ai/code/session_015jbnxZ6zYBf2ySwrpnPabm